### PR TITLE
[WIP] App-level tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ multipart = "0.15.3"
 slog = "2.4.1"
 slog-term = "2.4.0"
 slog-async = "2.3.0"
+tokio = "0.1"
 
 [dependencies.path_table]
 path = "path_table"

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,9 +25,9 @@ use crate::{
 /// This is a "handle" because it must be `Clone`, and endpoints are invoked with a fresh clone.
 /// They also hold a top-level router.
 pub struct App<Data> {
-    data: Data,
-    router: Router<Data>,
-    default_handler: BoxedEndpoint<Data>,
+    pub(crate) data: Data,
+    pub(crate) router: Router<Data>,
+    pub(crate) default_handler: BoxedEndpoint<Data>,
 }
 
 impl<Data: Clone + Send + Sync + 'static> App<Data> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,20 +18,20 @@ mod endpoint;
 mod extract;
 pub mod head;
 pub mod middleware;
-mod testing;
 mod request;
 mod response;
 mod router;
+mod testing;
 
 pub use crate::{
     app::{App, AppData},
-    testing::{test, Test},
-    testing::tokio_test::test as tokio_test,
     endpoint::Endpoint,
     extract::Extract,
     middleware::Middleware,
     request::{Compute, Computed, Request},
     response::{IntoResponse, Response},
     router::{Resource, Router},
+    testing::tokio_test::test as tokio_test,
+    testing::{test, Test},
 };
 pub use path_table::RouteMatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,15 @@ mod endpoint;
 mod extract;
 pub mod head;
 pub mod middleware;
+mod testing;
 mod request;
 mod response;
 mod router;
 
 pub use crate::{
     app::{App, AppData},
+    testing::{test, Test},
+    testing::tokio_test::test as tokio_test,
     endpoint::Endpoint,
     extract::Extract,
     middleware::Middleware,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,157 @@
+use crate::app::App;
+use tokio;
+
+use std::sync::Arc;
+
+use futures::{
+    future::FutureObj,
+    prelude::*,
+};
+
+use crate::{
+    body::Body,
+    router::{Router, RouteResult},
+    endpoint::BoxedEndpoint,
+    middleware::{RequestContext},
+};
+
+impl<Data: Clone + Send + Sync + 'static> App<Data> {
+    pub fn into_test(self) -> Test<Data> {
+        Test {
+            data: self.data,
+            router: Arc::new(self.router),
+            default_handler: Arc::new(self.default_handler),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Test<Data> {
+    data: Data,
+    router: Arc<Router<Data>>,
+    default_handler: Arc<BoxedEndpoint<Data>>,
+}
+
+impl<Data: Clone + Send + Sync + 'static> Test<Data> {
+    pub fn call(&mut self, req: http::Request<Body>) -> FutureObj<'static, Result<http::Response<Body>, std::io::Error>> {
+        let data = self.data.clone();
+        let router = self.router.clone();
+        let default_handler = self.default_handler.clone();
+
+        let req = req.map(Body::from);
+        let path = req.uri().path().to_owned();
+        let method = req.method().to_owned();
+
+        FutureObj::new(Box::new(
+            async move {
+                let RouteResult {
+                    endpoint,
+                    params,
+                    middleware,
+                } = router.route(&path, &method, &default_handler);
+
+                let ctx = RequestContext {
+                    app_data: data,
+                    req,
+                    params,
+                    endpoint,
+                    next_middleware: middleware,
+                };
+                let res = await!(ctx.next());
+
+                Ok(res.map(Into::into))
+            },
+        ))
+    }
+
+}
+
+pub fn test<T, F>(test: T) -> impl Future<Output=Result<(), Box<std::any::Any + 'static + Send>>>
+        where T: FnOnce() -> F,
+              F: Future<Output=()> + Send + 'static
+{
+    FutureObj::new(Box::new(
+        std::panic::AssertUnwindSafe(
+            test()
+        ).catch_unwind()
+    ))
+}
+
+pub mod tokio_test {
+    use futures::prelude::*;
+
+    pub fn test<T, F>(test: T)
+        where T: FnOnce() -> F,
+              T: 'static,
+              F: Future<Output=()> + Send + 'static
+    {
+        let runner = super::test(test).compat();
+
+        tokio::runtime::Runtime::new().unwrap().block_on(runner).unwrap();
+    }
+}
+
+#[macro_export]
+macro_rules! assert_status {
+    ($response:ident, $status:expr) => ({
+        let status = $response.status();
+        if !($response.status() == $status) {
+            panic!(r#"assertion failed:
+expected response code: `{:?}`,
+received response code: `{:?}`"#, $status, status)
+        }
+    });
+}
+
+#[macro_export]
+macro_rules! assert_ok {
+    ($response:ident) => ({
+        assert_status!($response, 200)
+    });
+}
+
+
+#[cfg(test)]
+mod test {
+    use crate::app::App;
+    use super::tokio_test::test;
+
+    #[test]
+    fn working_test() {
+        let mut app = App::new(());
+        app.at("/").get(async || "Hello, world!");
+        let mut tester = app.into_test();
+
+        let request = http::Request::builder()
+            .method("GET")
+            .body(Vec::new().into())
+            .unwrap();
+
+        test(
+            async move || {
+                let response = await!(tester.call(request)).unwrap();
+                assert_ok!(response);
+            }
+        )
+    }
+
+    #[test]
+    #[should_panic]
+    fn failing_test() {
+        let mut app = App::new(());
+        app.at("/").get(async || "Hello, world!");
+        let mut tester = app.into_test();
+
+        let request = http::Request::builder()
+            .method("POST")
+            .body(Vec::new().into ())
+            .unwrap();
+
+        test(
+            async move || {
+                let response = await!(tester.call(request)).unwrap();
+                assert_ok!(response);
+            }
+        )
+    }
+}


### PR DESCRIPTION
This PR adds app-level tests, to allow testing a full constructed app and interaction with it and is very much work in progress.

It currently works similar to the Service trait.

Most of the code isn't very tide specific, for discussion and bikeshedding, I'd like to keep it on the module for now, before potentially moving it out into a crate.

## Description
* Adds a `testing` module containing the ability to turn an App into a `Test` app, which can be called.
* Contains two main functions: `test` and `tokio_test::test`, which provide the necessary wrappers around panicing and reactor handling
* Adds examples for response specific macros `assert_status`, `assert_ok`, etc.)
    * Misses any kind of ergonomics around building requests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
By writing tests using it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
