### PR TITLE
[WIP] New Tide middleware: Automatic compression handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_qs = "0.4.1"
 slog = "2.4.1"
 slog-term = "2.4.0"
 slog-async = "2.3.0"
+flate2 = "1.0.6"
 
 [dependencies.multipart]
 version = "0.15.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use crate::{
     app::{App, AppData},
     endpoint::Endpoint,
     extract::Extract,
-    middleware::Middleware,
+    middleware::{Compression, Middleware},
     request::{Compute, Computed, Request},
     response::{IntoResponse, Response},
     router::{Resource, Router},

--- a/src/middleware/compression.rs
+++ b/src/middleware/compression.rs
@@ -1,0 +1,204 @@
+use futures::future::FutureObj;
+
+use crate::body::Body;
+use crate::{middleware::RequestContext, Middleware, Response};
+use http::header::{HeaderValue, ACCEPT_ENCODING, CONTENT_ENCODING};
+
+use std::io::Read;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Encoding {
+    Gzip,
+    Deflate,
+    Identity,
+}
+
+impl Encoding {
+    fn parse(i: &str) -> Option<Encoding> {
+        use self::Encoding::*;
+        match i {
+            "gzip" => Some(Gzip),
+            "deflate" => Some(Deflate),
+            "identity" => Some(Identity),
+            _ => None,
+        }
+    }
+
+    fn header_value(self) -> HeaderValue {
+        use self::Encoding::*;
+        match self {
+            Gzip => HeaderValue::from_str("gzip").unwrap(),
+            Deflate => HeaderValue::from_str("deflate").unwrap(),
+            Identity => HeaderValue::from_str("identity").unwrap(),
+        }
+    }
+}
+
+/// Tide's compression middleware.
+/// Will pick preferred supported format from "Accept-Encoding" header
+/// and serialize response accordingly
+pub struct Compression {
+    default: Encoding,
+}
+
+impl Compression {
+    pub fn new() -> Self {
+        Compression {
+            default: Encoding::Gzip,
+        }
+    }
+
+    pub fn with_default(default: Encoding) -> Self {
+        Compression { default }
+    }
+
+    fn preferred_encoding(headers: &http::HeaderMap) -> Option<Encoding> {
+        headers
+            .get_all(ACCEPT_ENCODING)
+            .iter()
+            .filter_map(|hval| hval.to_str().ok())
+            .flat_map(|val| val.split(|c| c == ','))
+            .filter_map(|encoding| Encoding::parse(encoding))
+            .next()
+    }
+
+    fn apply(body: &[u8], encoding: Encoding) -> Option<Vec<u8>> {
+        let mut buf = Vec::new();
+        match encoding {
+            Encoding::Gzip => {
+                let mut gz = flate2::bufread::GzEncoder::new(body, flate2::Compression::fast());
+                gz.read_to_end(&mut buf).ok()?;
+            }
+
+            Encoding::Deflate => {
+                let mut deflate =
+                    flate2::bufread::DeflateEncoder::new(body, flate2::Compression::fast());
+                deflate.read_to_end(&mut buf).ok()?;
+            }
+
+            _ => return None,
+        };
+        Some(buf)
+    }
+}
+
+impl Default for Compression {
+    fn default() -> Self {
+        Compression::new()
+    }
+}
+
+/// Picks best ecnoding from request and accordingly set response header and body.
+impl<Data: Clone + Send> Middleware<Data> for Compression {
+    fn handle<'a>(&'a self, ctx: RequestContext<'a, Data>) -> FutureObj<'a, Response> {
+        FutureObj::new(Box::new(
+            async move {
+                let encoding = Self::preferred_encoding(ctx.req.headers()).unwrap_or(self.default);
+                let mut res: crate::Response = await!(ctx.next());
+                let body = await!(res.body_mut().read_to_vec()).expect("failed to read reply");
+                if let Some(compressed) = Compression::apply(&body, encoding) {
+                    *res.body_mut() = Body::from(compressed);
+                    res.headers_mut()
+                        .append(CONTENT_ENCODING, encoding.header_value());
+                } else {
+                    *res.body_mut() = Body::from(body);
+                }
+                res
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+
+    use super::*;
+    use crate::{body::Body, endpoint::BoxedEndpoint, middleware::RequestContext, Request};
+    use http::status::StatusCode;
+
+    static LOREM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+    async fn lorem() -> String {
+        String::from(LOREM)
+    }
+
+    #[test]
+    fn identity() {
+        let mut req = Request::new(Body::empty());
+        req.headers_mut()
+            .append(ACCEPT_ENCODING, HeaderValue::from_str("identity").unwrap());
+        let mdw = Compression::default();
+        let endpoint = BoxedEndpoint::new(lorem);
+        let ctx = RequestContext {
+            app_data: (),
+            req,
+            params: None,
+            endpoint: &endpoint,
+            next_middleware: &[],
+        };
+        let mut resp = block_on(mdw.handle(ctx));
+        assert_eq!(StatusCode::OK, resp.status());
+        let body = block_on(resp.body_mut().read_to_vec()).expect("Failed to read body");
+        assert_eq!(
+            std::str::from_utf8(&body).expect("Failed to convert to UTF-8"),
+            LOREM
+        );
+        assert!(resp.headers().get(CONTENT_ENCODING).is_none());
+    }
+
+    #[test]
+    fn default_gzip() {
+        let req = Request::new(Body::empty());
+        let mdw = Compression::default();
+        let endpoint = BoxedEndpoint::new(lorem);
+        let ctx = RequestContext {
+            app_data: (),
+            req,
+            params: None,
+            endpoint: &endpoint,
+            next_middleware: &[],
+        };
+        let mut resp = block_on(mdw.handle(ctx));
+        assert_eq!(StatusCode::OK, resp.status());
+
+        let body: Vec<u8> = block_on(resp.body_mut().read_to_vec()).expect("Failed to read body");
+        assert_eq!(
+            resp.headers()
+                .get(CONTENT_ENCODING)
+                .expect("No content-encoding header"),
+            "gzip"
+        );
+        let bytes: &[u8] = &body;
+        let mut decoder = flate2::read::GzDecoder::new(bytes);
+        let mut s = String::new();
+        decoder.read_to_string(&mut s).unwrap();
+        assert_eq!(s, LOREM);
+    }
+
+    fn header_map(accept_encoding: &[&str]) -> hyper::HeaderMap {
+        let mut hm = hyper::HeaderMap::new();
+        for encoding in accept_encoding {
+            hm.insert(ACCEPT_ENCODING, encoding.parse().unwrap());
+        }
+        hm
+    }
+
+    macro_rules! assert_best_encoding {
+        ($encodings:expr, $expected:expr) => {
+            assert_eq!(
+                Compression::preferred_encoding(&header_map($encodings)),
+                $expected
+            );
+        };
+    }
+
+    #[test]
+    fn preferred_encoding() {
+        assert_best_encoding!(&[], None);
+        assert_best_encoding!(&["gzip"], Some(Encoding::Gzip));
+        assert_best_encoding!(&["unknown"], None);
+        assert_best_encoding!(&["gzip,deflate,identity"], Some(Encoding::Gzip));
+        assert_best_encoding!(&["unknown", "deflate"], Some(Encoding::Deflate));
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -4,9 +4,10 @@ use futures::future::FutureObj;
 
 use crate::{endpoint::BoxedEndpoint, Request, Response, RouteMatch};
 
+pub mod compression;
 mod default_headers;
 pub mod logger;
-
+pub use self::compression::Compression;
 pub use self::default_headers::DefaultHeaders;
 
 /// Middleware that wraps around remaining middleware chain.


### PR DESCRIPTION
## Description

This PR aims at brining a new compression handling middleware to Tide.
The goal of it would to automatically:

- decompress incoming data if it's compressed
- detect the preferred encoding from the request and encode the response accordingly.

This is still work-in-progress for several reasons:

### Missing features:
Some target features are not there yet (but I guess this could come with time)

- Decompression of request
- Brotli support
- Quality value support (by the way, I expected to find their parsing in http/hyper without success. Did I miss something?)

### Streaming compression
I struggled (and actually didn't manage) to compress the body as a stream of chunks.

Trying to use the `Stream` impl of `hyper::Body`, I encountered a few challenges:
- Compiler complaints as I get mixed up between futures 0.1 and 0.3 versions
- I was not familiar enough with the `flate2` interface. Can the `AsyncRead`/`AsyncWrite` version be used?

I guess I should probably manually implement a `Stream` and call [`flate2::Compress`](https://docs.rs/flate2/1.0.6/flate2/struct.Compress.html) raw struct.
Any hint on how to best go about this are very welcome :)

Meanwhile, to get something working, I used `read_to_vec` on `tide::Body`. This works well for small response… But will put more memory pressure payloads (e.g. streaming a file compressed).

### Error handling
For some errors, it is quite straight-forward to have a fallback behaviour (e.g. if compression fails, return body as is), but others are un-clear to me (e.g. what should happen in `read_to_vec` fails?).

## Motivation and Context
This follows from issue #26

## How Has This Been Tested?
- (automated) Unittests in the compression middleware
- (manual) Integrated to the hello world example and ping via `curl` with various headers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
