### PR TITLE
Extend extractors with an optional seed per endpoint.

### DIFF
--- a/examples/seeded_extractor.rs
+++ b/examples/seeded_extractor.rs
@@ -1,5 +1,6 @@
 #![feature(async_await, futures_api)]
 
+use tide::Seeded;
 use tide::head::{NamedHeader, Header, SegmentName, Named};
 use http::header::{HeaderName, HeaderValue};
 
@@ -13,7 +14,7 @@ async fn display_number(nr: Named<i32>) -> String {
 
 fn main() {
     let mut app = tide::App::new(());
-    app.at("/").get_with(display_header, NamedHeader(HeaderName::from_static("user-agent")));
-    app.at("/numbered/{num}").get_with(display_number, SegmentName("num".into()));
+    app.at("/").get(Seeded(display_header, NamedHeader(HeaderName::from_static("user-agent"))));
+    app.at("/numbered/{num}").get(Seeded(display_number, SegmentName("num".into())));
     app.serve();
 }

--- a/examples/seeded_extractor.rs
+++ b/examples/seeded_extractor.rs
@@ -1,0 +1,14 @@
+#![feature(async_await, futures_api)]
+
+use tide::head::{NamedHeader, Header};
+use http::header::{HeaderName, HeaderValue};
+
+async fn display_header(value: Header<HeaderValue>) -> String {
+    String::from_utf8_lossy(value.0.as_ref()).into_owned()
+}
+
+fn main() {
+    let mut app = tide::App::new(());
+    app.at("/").get_with(display_header, (NamedHeader(HeaderName::from_static("user-agent")),));
+    app.serve();
+}

--- a/examples/seeded_extractor.rs
+++ b/examples/seeded_extractor.rs
@@ -1,14 +1,19 @@
 #![feature(async_await, futures_api)]
 
-use tide::head::{NamedHeader, Header};
+use tide::head::{NamedHeader, Header, SegmentName, Named};
 use http::header::{HeaderName, HeaderValue};
 
 async fn display_header(value: Header<HeaderValue>) -> String {
     String::from_utf8_lossy(value.0.as_ref()).into_owned()
 }
 
+async fn display_number(nr: Named<i32>) -> String {
+    format!("Segment number: {}", nr.0)
+}
+
 fn main() {
     let mut app = tide::App::new(());
-    app.at("/").get_with(display_header, (NamedHeader(HeaderName::from_static("user-agent")),));
+    app.at("/").get_with(display_header, NamedHeader(HeaderName::from_static("user-agent")));
+    app.at("/numbered/{num}").get_with(display_number, SegmentName("num".into()));
     app.serve();
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -18,3 +18,35 @@ pub trait Extract<Data>: Send + Sized + 'static {
         store: &Store,
     ) -> Self::Fut;
 }
+
+/// A seed to extract `Param` for an app with `Data`
+pub trait ExtractSeed<Param, Data>: Send + Sync + Sized + 'static where Param: Send + Sized + 'static {
+    /// The async result of `extract`.
+    ///
+    /// The `Err` case represents that the endpoint should not be invoked, but
+    /// rather the given response should be returned immediately.
+    type Fut: Future<Output = Result<Param, Response>> + Send + 'static;
+
+    /// Attempt to extract a value from the given request.
+    fn extract(&self,
+        data: &mut Data,
+        req: &mut Request,
+        params: &Option<RouteMatch<'_>>,
+        store: &Store,
+    ) -> Self::Fut;
+}
+
+impl<Param, Data> ExtractSeed<Param, Data> for ()
+    where Param: Extract<Data> + Send + Sized + 'static
+{
+    type Fut = Param::Fut;
+
+    fn extract(&self,
+        data: &mut Data,
+        req: &mut Request,
+        params: &Option<RouteMatch<'_>>,
+        store: &Store,
+    ) -> Self::Fut {
+        Param::extract(data, req, params, store)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::{
     app::{App, AppData, Server},
     configuration::ExtractConfiguration,
     cookies::Cookies,
-    endpoint::Endpoint,
+    endpoint::{Endpoint, Seeded},
     extract::{Extract, ExtractSeed},
     middleware::Middleware,
     request::{Compute, Computed, Request},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::{
     configuration::ExtractConfiguration,
     cookies::Cookies,
     endpoint::Endpoint,
-    extract::Extract,
+    extract::{Extract, ExtractSeed},
     middleware::Middleware,
     request::{Compute, Computed, Request},
     response::{IntoResponse, Response},

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::{
     configuration::Store,
-    endpoint::{BoxedEndpoint, Endpoint},
+    endpoint::{BoxedEndpoint, Endpoint, Seeded},
     Middleware,
 };
 use path_table::{PathTable, RouteMatch};
@@ -277,6 +277,12 @@ impl<'a, Data> Resource<'a, Data> {
     /// Add an endpoint for `GET` requests
     pub fn get<T: Endpoint<Data, U>, U>(&mut self, ep: T) -> &mut EndpointData<Data> {
         self.method(http::Method::GET, ep)
+    }
+
+    pub fn get_with<T, S, U>(&mut self, ep: T, seed: S) -> &mut EndpointData<Data>
+        where Seeded<T, S>: Endpoint<Data, U>
+    {
+        self.method(http::Method::GET, Seeded(ep, seed))
     }
 
     /// Add an endpoint for `HEAD` requests

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::{
     configuration::Store,
-    endpoint::{BoxedEndpoint, Endpoint, Seeded},
+    endpoint::{BoxedEndpoint, Endpoint},
     Middleware,
 };
 use path_table::{PathTable, RouteMatch};
@@ -277,12 +277,6 @@ impl<'a, Data> Resource<'a, Data> {
     /// Add an endpoint for `GET` requests
     pub fn get<T: Endpoint<Data, U>, U>(&mut self, ep: T) -> &mut EndpointData<Data> {
         self.method(http::Method::GET, ep)
-    }
-
-    pub fn get_with<T, S, U>(&mut self, ep: T, seed: S) -> &mut EndpointData<Data>
-        where Seeded<T, S>: Endpoint<Data, U>
-    {
-        self.method(http::Method::GET, Seeded(ep, seed))
     }
 
     /// Add an endpoint for `HEAD` requests


### PR DESCRIPTION
## Description
The `Extract`-trait was complemented by another trait to allow one type to provide an seed for extracting multiple others. All existing self-extracting types (`Body`, `Json`, `Path`, …) are provided with an `impl Extract<T, Data> for ()`. A second impl for `Endpoint` has been created: `Seeded`. It is essentially a tuple of a standard endpoint function and a `Sync + 'static` seed tuple which provides the seeds for extracting the function arguments.

The new trait looks as follows (trait bounds may be stricter than necessary), fairly closely modeled after [`serde::de::DeserializeSeed`](https://docs.rs/serde/1.0.89/serde/de/trait.DeserializeSeed.html):

```rust
/// An extractor for an app with `Data`
pub trait ExtractSeed<Param, Data>: Send + Sync + Sized + 'static 
    where Param: Send + Sized + 'static 
{
    /// The async result of `extract`.
    ///
    /// The `Err` case represents that the endpoint should not be invoked, but
    /// rather the given response should be returned immediately.
    type Fut: Future<Output = Result<Param, Response>> + Send + 'static;

    /// Attempt to extract a value from the given request.
    fn extract(&self,
        data: &mut Data,
        req: &mut Request,
        params: &Option<RouteMatch<'_>>,
        store: &Store,
    ) -> Self::Fut;
}
```

An example `impl` for this trait (except `()` for all `Extract`), uses a runtime provided header name to extract the corresponding header:

```rust
/// Wrapper for conenience of disambiguiation, can be discussed
pub struct NamedHeader(pub http::header::HeaderName);

impl<T: 'static, S: 'static> ExtractSeed<Header<T>, S> for NamedHeader 
    where T: From<http::header::HeaderValue> + Send
{
    type Fut = future::Ready<Result<Header<T>, Response>>;
    fn extract(&self,
        data: &mut S,
        req: &mut Request,
        params: &Option<RouteMatch<'_>>,
        store: &Store,
    ) -> Self::Fut {
        let header = req.headers().get(&self.0);
        match header {
            Some(value) => future::ok(Header(value.clone().into())),
            None => future::err(http::status::StatusCode::BAD_REQUEST.into_response()),
        }
    }
}
```

Similar to the other `Endpoint` impl for closures, for `Seeded` we also use a closure to provide implementations up to 9 arguments. It follows the other implementation closely, only extending the required trait parameters by new ones and replacing the extraction logic with the following: 

```
// within the endpoint macro, from
let ($($Y),*) = &self.1;
$(let $X = <$Y as ExtractSeed<$X, Data>>::extract($Y, &mut data, &mut req, &params, store);)*
```

## Motivation and Context
This allows an extracted value to depend on information only available at runtime. Such behaviour was previously only (nicely, without `static Mutex<T>`) possible by creating a new generic type wrapping the actually intended parameter type. This generic would then take a type argument implementing a trait. However, this trait implementation must typically be deferred to an enduser who has to customize it according to their own app state type. Futhermore, this needs one type and impl per endpoint with different configuration. 

One problem where this would be applicable is authentication/authorization. Different endpoints may require different security realms or permissions, different user names etc. Encoding this all into types with static functions to derive different runtime values from app state quickly becomes a hassle of writing the same implementation with just slightly different constants. However, the outcome parameter into endpoint functions should mostly be very similar. A single value containing the name of the authorized entity. By implementing this via type-level generics though, the type of this value quickly becomes much much more complex. Moving the necessary information into runtime instead allows one to use a single type to guarantee the necessary invariant.

Programmers may still use newtype structs to type such values more securely but these can be expressed more succinctly without generics.

This could be a solution for #108 as `NamedComponent` may gain a seed which gets supplied with the name at runtime. This has been exemplified in the example.

This solution is not intended to encourage arbitrary reconfiguration of extractor seeds at runtime although it could allow it. The seeds are hidden behind a `BoxedEndpoint` as soon as they are provided to the router and may only inspect themselves immutably while requiring `Send + Sync`.

## How Has This Been Tested?

There is [an example](https://github.com/rust-net-web/tide/blob/d40927fa8c652bd12996114f232d7e3e8abea075/examples/seeded_extractor.rs) that extracts the `user-agent` header based on a runtime constructed `HeaderName`. Another route extracts the path component `num` where `num` was supplied via a static string instead of an associated item on a type parameter.

Other tests in `cfg(test)` will follow as implementation goes beyond Poc. No other tests had to be modified for these changes to work as the `App` interface remained unchanged.

## Other TODOs

- [ ] Provide missing wrappers like `Resource::get_with`
- [ ] Consistently create dynamic seeds for extracted types where applicable (in the style of `SegmentName`, `NamedHeader`)
- [ ] Use the same naming scheme for all seeds and types

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (Not yet)
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes. (Not yet)
- [ ] All new and existing tests passed. (All existing, new tests to come)

__edit 2019-01-21 (yw):__ updated link to example, and added syntax highlighting.
