### PR TITLE
Add external crate http_service_mock, delete local TestBackend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ hyper = ["http-service-hyper"]
 basic-cookies = "0.1.3"
 juniper = "0.10.0"
 structopt = "0.2.14"
+http-service-mock = "0.1.0"

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,34 +1,11 @@
 #![feature(futures_api, async_await)]
 
-use futures::{executor::block_on, prelude::*};
-use http_service::{Body, HttpService, Request, Response};
+use http_service::{Body};
+use futures::{executor::block_on};
 use tide::{
-    head::{Named, NamedSegment},
-    Server,
+    head::{Named, NamedSegment}
 };
-
-struct TestBackend<T: HttpService> {
-    service: T,
-    connection: T::Connection,
-}
-
-impl<T: HttpService> TestBackend<T> {
-    fn wrap(service: T) -> Result<Self, <T::ConnectionFuture as TryFuture>::Error> {
-        let connection = block_on(service.connect().into_future())?;
-        Ok(Self {
-            service,
-            connection,
-        })
-    }
-
-    fn simulate(&mut self, req: Request) -> Result<Response, <T::Fut as TryFuture>::Error> {
-        block_on(
-            self.service
-                .respond(&mut self.connection, req)
-                .into_future(),
-        )
-    }
-}
+use http_service_mock::{make_server};
 
 struct Number(i32);
 
@@ -43,20 +20,15 @@ impl std::str::FromStr for Number {
         s.parse().map(|num| Number(num))
     }
 }
-
 async fn add_one(Named(Number(num)): Named<Number>) -> String {
     (num + 1).to_string()
 }
 
-fn make_server() -> TestBackend<Server<()>> {
-    let mut app = tide::App::new(());
-    app.at("/add_one/{num}").get(add_one);
-    TestBackend::wrap(app.into_http_service()).unwrap()
-}
-
 #[test]
 fn wildcard() {
-    let mut server = make_server();
+    let mut app = tide::App::new(());
+    app.at("/add_one/{num}").get(add_one); 
+    let mut server = make_server(app.into_http_service()).unwrap();
 
     let req = http::Request::get("/add_one/3")
         .body(Body::empty())
@@ -77,7 +49,8 @@ fn wildcard() {
 
 #[test]
 fn invalid_segment_error() {
-    let mut server = make_server();
+    let app = tide::App::new(());
+    let mut server = make_server(app.into_http_service()).unwrap();
 
     let req = http::Request::get("/add_one/a")
         .body(Body::empty())
@@ -88,7 +61,8 @@ fn invalid_segment_error() {
 
 #[test]
 fn not_found_error() {
-    let mut server = make_server();
+    let app = tide::App::new(());
+    let mut server = make_server(app.into_http_service()).unwrap();
 
     let req = http::Request::get("/add_one/").body(Body::empty()).unwrap();
     let res = server.simulate(req).unwrap();

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -49,7 +49,8 @@ fn wildcard() {
 
 #[test]
 fn invalid_segment_error() {
-    let app = tide::App::new(());
+    let mut app = tide::App::new(());
+    app.at("/add_one/{num}").get(add_one); 
     let mut server = make_server(app.into_http_service()).unwrap();
 
     let req = http::Request::get("/add_one/a")
@@ -61,7 +62,8 @@ fn invalid_segment_error() {
 
 #[test]
 fn not_found_error() {
-    let app = tide::App::new(());
+    let mut app = tide::App::new(());
+    app.at("/add_one/{num}").get(add_one); 
     let mut server = make_server(app.into_http_service()).unwrap();
 
     let req = http::Request::get("/add_one/").body(Body::empty()).unwrap();


### PR DESCRIPTION
This solves [ust-net-web/tide#15](https://github.com/rust-net-web/tide/issues/15). We wanted to extract the `HttpBackend` inside the tests, and offer it inside the `http-service` create (https://github.com/rust-net-web/http-service/pull/6).

## Description
I removed the `HttpBackend` from the `wildcard.rs` tests, and used the external crate (which needs to be merged and pushed first inside `http-service`).

## Motivation and Context
After the change, we are able to offer a TestBackend which is not tied to `Tide`.

## How Has This Been Tested?
The PR in `http-service` needs to be merged first. I tested it locally and it ran fine. 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
