### PR TITLE
Implement query parameter extraction

### DIFF
--- a/src/head.rs
+++ b/src/head.rs
@@ -203,9 +203,9 @@ impl<T: NamedSegment, S: 'static> Extract<S> for Named<T> {
 
 /// An extractor for query string in URL
 ///
-pub struct UrlQuery<T>(pub T);
+pub struct QueryString<T>(pub T);
 
-impl<S, T> Extract<S> for UrlQuery<T>
+impl<S, T> Extract<S> for QueryString<T>
 where
     T: Send + std::str::FromStr + 'static,
     S: 'static,
@@ -219,7 +219,7 @@ where
     ) -> Self::Fut {
         req.uri().query().and_then(|q| q.parse().ok()).map_or(
             future::err(http::status::StatusCode::BAD_REQUEST.into_response()),
-            |q| future::ok(UrlQuery(q)),
+            |q| future::ok(QueryString(q)),
         )
     }
 }

--- a/src/head.rs
+++ b/src/head.rs
@@ -224,6 +224,47 @@ where
     }
 }
 
+/// An extractor for query string parameters.
+///
+/// # Examples
+///
+/// Extract queries like `?title=Hitchhiker%27s+Guide&author=Adams`:
+///
+/// ```rust
+/// #![feature(async_await, futures_api)]
+///
+/// use serde_derive::Deserialize;
+/// use tide::head::QueryParams;
+///
+/// #[derive(Deserialize)]
+/// struct Book {
+///     title: String,
+///     author: String,
+/// }
+///
+/// async fn search_book(QueryParams(book): QueryParams<Book>) -> String {
+///     format!("title: {}, author: {}", book.title, book.author)
+/// }
+/// #
+/// # fn main() {
+/// #     use http_service::Body;
+/// #     use http_service_mock::make_server;
+/// #     use futures::executor::block_on;
+/// #     use std::str;
+/// #
+/// #     let mut app = tide::App::new(());
+/// #     app.at("/search").get(search_book);
+/// #     let mut server = make_server(app.into_http_service()).unwrap();
+/// #
+/// #     let req = http::Request::get("/search?title=Hitchhiker%27s+Guide&author=Adams")
+/// #         .body(Body::empty())
+/// #         .unwrap();
+/// #
+/// #     let res = server.simulate(req).unwrap();
+/// #     let body = block_on(res.into_body().into_vec()).unwrap();
+/// #     assert_eq!(str::from_utf8(&body).unwrap(), "title: Hitchhiker's Guide, author: Adams");
+/// # }
+/// ```
 pub struct QueryParams<T>(pub T);
 
 impl<S, T> Extract<S> for QueryParams<T>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `serde_qs` based query string extraction (`QueryParams`) next to the existing `UrlQuery` (-> `QueryString`), which extracts the entire query string and parses using `FromStr`.

## Motivation and Context
See #147.

## How Has This Been Tested?
~So far only type based plumbing.~ Documentation test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~Bug fix (non-breaking change which fixes an issue)~
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
