### PR TITLE
Use Arc<Store> instead of Store for lazy loading

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -86,7 +86,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
             router: Router::new(),
             default_handler: EndpointData {
                 endpoint: BoxedEndpoint::new(async || http::status::StatusCode::NOT_FOUND),
-                store: Store::new(),
+                store: Arc::new(Store::new()),
             },
         };
 
@@ -240,7 +240,7 @@ impl<T: Clone + Send + 'static> Extract<T> for AppData<T> {
         data: &mut T,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         future::ok(AppData(data.clone()))
     }

--- a/src/body.rs
+++ b/src/body.rs
@@ -79,6 +79,7 @@ use http_service::Body;
 use multipart::server::Multipart;
 use std::io::Cursor;
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 use crate::{configuration::Store, Extract, IntoResponse, Request, Response, RouteMatch};
 
@@ -101,7 +102,7 @@ impl<S: 'static> Extract<S> for MultipartForm {
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         // https://stackoverflow.com/questions/43424982/how-to-parse-multipart-forms-using-abonander-multipart-with-rocket
 
@@ -152,7 +153,7 @@ impl<T: Send + serde::de::DeserializeOwned + 'static, S: 'static> Extract<S> for
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         let body = std::mem::replace(req.body_mut(), Body::empty());
         FutureObj::new(Box::new(
@@ -204,7 +205,7 @@ impl<T: Send + serde::de::DeserializeOwned + 'static, S: 'static> Extract<S> for
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         let body = std::mem::replace(req.body_mut(), Body::empty());
         FutureObj::new(Box::new(
@@ -252,7 +253,7 @@ impl<S: 'static> Extract<S> for Str {
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         let body = std::mem::replace(req.body_mut(), Body::empty());
 
@@ -288,7 +289,7 @@ impl<S: 'static> Extract<S> for StrLossy {
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         let body = std::mem::replace(req.body_mut(), Body::empty());
 
@@ -324,7 +325,7 @@ impl<S: 'static> Extract<S> for Bytes {
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         let body = std::mem::replace(req.body_mut(), Body::empty());
 

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -3,6 +3,7 @@
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
+use std::sync::Arc;
 
 use futures::future::FutureObj;
 
@@ -106,7 +107,7 @@ where
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         // The return type here is Option<K>, but the return type of the result of the future is
         // Result<ExtractConfiguration<T>, Response>, so rustc can infer that K == T, so we do not

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,5 +1,6 @@
 use cookie::{Cookie, CookieJar, ParseError};
 use futures::future;
+use std::sync::Arc;
 
 use crate::{configuration::Store, response::IntoResponse, Extract, Request, Response, RouteMatch};
 
@@ -28,7 +29,7 @@ impl<S: 'static> Extract<S> for Cookies {
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         let cookie_jar = match req.headers().get("Cookie") {
             Some(raw_cookies) => parse_from_header(raw_cookies.to_str().unwrap()),

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,4 +1,5 @@
 use futures::prelude::*;
+use std::sync::Arc;
 
 use crate::{configuration::Store, Request, Response, RouteMatch};
 
@@ -15,6 +16,6 @@ pub trait Extract<Data>: Send + Sized + 'static {
         data: &mut Data,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut;
 }

--- a/src/head.rs
+++ b/src/head.rs
@@ -102,7 +102,7 @@ impl<T: Send + 'static + std::str::FromStr, S: 'static> Extract<S> for Path<T> {
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         let &PathIdx(i) = req.extensions().get::<PathIdx>().unwrap_or(&PathIdx(0));
         req.extensions_mut().insert(PathIdx(i + 1));
@@ -185,7 +185,7 @@ impl<T: NamedSegment, S: 'static> Extract<S> for Named<T> {
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         match params {
             Some(params) => params
@@ -215,7 +215,7 @@ where
         data: &mut S,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         req.uri().query().and_then(|q| q.parse().ok()).map_or(
             future::err(http::status::StatusCode::BAD_REQUEST.into_response()),

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,7 @@
 use futures::future;
 use http_service::Body;
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 use crate::{configuration::Store, Extract, Response, RouteMatch};
 
@@ -58,7 +59,7 @@ impl<Data: 'static, T: Compute> Extract<Data> for Computed<T> {
         data: &mut Data,
         req: &mut Request,
         params: &Option<RouteMatch<'_>>,
-        store: &Store,
+        store: &Arc<Store>,
     ) -> Self::Fut {
         future::ok(Computed(T::compute(req)))
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change store's type used in `Router` and `Extract` to wrapped one, to load configurations after extraction.
This change affects to public trait.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes we define services for SoC. They would be dependent on another services.
Tide has per-endpoint configuration, so every services should be able to read it.

One way for it is passing a store's reference in services' constructor recursively while extraction. This looks good, but if some services depend on same services, duplicate object will be created.
Another way is extract (partial) clone of store and share it across services. If the store is big, per-request clone will be high cost.

This change helps latter one. Instead of cloning a store directly, we can clone just shared reference with few overhead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are no additional tests.
Implementations of `Extract` are affected, but it can be easily fixed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.