### PR TITLE
introduce better app configurability

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -79,8 +79,7 @@ pub struct App<Data> {
 
 impl<Data: Clone + Send + Sync + 'static> App<Data> {
     /// Set up a new app with some initial `data`.
-    pub fn new(data: Data) -> App<Data> {
-        let logger = RootLogger::new();
+    pub fn empty(data: Data) -> App<Data> {
         let mut app = App {
             data,
             router: Router::new(),
@@ -90,10 +89,15 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
             },
         };
 
+        app.setup_configuration();
+        app
+    }
+
+    pub fn new(data: Data) -> App<Data> {
+        let mut app = App::empty(data);
+        let logger = RootLogger::new();
         // Add RootLogger as a default middleware
         app.middleware(logger);
-        app.setup_configuration();
-
         app
     }
 


### PR DESCRIPTION
Currently, `App::new()` automatically sets up logging middleware. When this is not desirable there is not way to remove it. 

While configurability of tide in general is an ongoing process, and will change as we go, I expect some form default middleware and other options to be pre-configured, logging being a prime example. However there should also be a way out for people who'd prefer starting from scratch. 

So, as the configuration story improves, I think a nice to way to handle this throughout (either for just the current evolutionary phases of tide, or through to more mature phases if it desired), would be to introduce to a method `App::empty()` which is basically `new` with bare bones. And `new` as usual, provides sensible defaults. 