### PR TITLE
Re-export http crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,5 @@ pub use crate::{
     response::Response,
     route::Route,
 };
+
+pub use http;


### PR DESCRIPTION
## Description

I added `pub use http;` in `lib.rs`

## Motivation and Context

Since `tide` heavily depends on `http` crate, it would be great if we can use `http` crate without adding to `Cargo.toml`.

## How Has This Been Tested?

I checked via `cargo doc` that the `http` crate is re-exported.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
