### PR TITLE
fix: catch all in 'catch_all'

### DIFF
--- a/examples/catch_all.rs
+++ b/examples/catch_all.rs
@@ -3,12 +3,12 @@
 use tide::Context;
 
 async fn echo_path(cx: Context<()>) -> String {
-    let path: String = cx.param("path").unwrap();
+    let path: String = cx.param("path*").unwrap();
     format!("Your path is: {}", path)
 }
 
 fn main() {
     let mut app = tide::App::new(());
-    app.at("/echo_path/:path").get(echo_path);
+    app.at("/echo_path/:path*").get(echo_path);
     app.serve("127.0.0.1:8000").unwrap();
 }


### PR DESCRIPTION
Fix #167 in the right way

In example 'catch_all', I do belive that we should catch 'http://127.0.0.1:8000/echo_path/foo' and 'http://127.0.0.1:8000/echo_path/foo/foo', which means, [this fix](https://github.com/rustasync/tide/pull/168) is Wrong

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
