### PR TITLE
fix: Capture wildcard path correctly, resolve #167.

### DIFF
--- a/examples/catch_all.rs
+++ b/examples/catch_all.rs
@@ -9,6 +9,6 @@ async fn echo_path(cx: Context<()>) -> String {
 
 fn main() {
     let mut app = tide::App::new(());
-    app.at("/echo_path/:path").get(echo_path);
+    app.at("/echo_path/*path").get(echo_path);
     app.serve("127.0.0.1:8000").unwrap();
 }


### PR DESCRIPTION
c70d2bc resolved the panic raised in the issue, but it also exposed my
ignorance with regards to route-recognizer, our new routing library.

Placing the `*` after a named param, as it was in the original example,
leads to the behavior mentioned in #167. route-recognizer is operating
exactly as intended. `:path*` doesn't capture additional URL segments,
where `*path` does. (It also appends `*` to the parameter key, as well.)