### PR TITLE
Add query string extension trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ slog = "2.4.1"
 slog-async = "2.3.0"
 slog-term = "2.4.0"
 typemap = "0.3.3"
+serde_urlencoded = "0.5.5"
 
 [dependencies.http-service-hyper]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod cookies;
 mod endpoint;
 pub mod forms;
 pub mod middleware;
+pub mod querystring;
 pub mod response;
 mod route;
 mod router;

--- a/src/querystring.rs
+++ b/src/querystring.rs
@@ -1,0 +1,80 @@
+use crate::{error::Error, Context};
+use http::StatusCode;
+use serde::Deserialize;
+
+/// An extension trait for `Context`, providing query string deserialization.
+pub trait ExtractQuery<'de> {
+    fn url_query<T: Deserialize<'de>>(&'de self) -> Result<T, Error>;
+}
+
+impl<'de, Data> ExtractQuery<'de> for Context<Data> {
+    #[inline]
+    fn url_query<T: Deserialize<'de>>(&'de self) -> Result<T, Error> {
+        let query = self.uri().query();
+
+        if query.is_none() {
+            return Err(Error::from(StatusCode::BAD_REQUEST));
+        }
+
+        Ok(serde_urlencoded::from_str(query.unwrap())
+            .map_err(|_| Error::from(StatusCode::BAD_REQUEST))?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use http_service::Body;
+    use http_service_mock::make_server;
+    use serde_derive::Deserialize;
+
+    #[derive(Deserialize)]
+    struct Params {
+        msg: String,
+    }
+
+    async fn handler(cx: crate::Context<()>) -> Result<String, Error> {
+        let p = cx.url_query::<Params>()?;
+        Ok(p.msg)
+    }
+
+    fn app() -> crate::App<()> {
+        let mut app = crate::App::new(());
+        app.at("/").get(handler);
+        app
+    }
+
+    #[test]
+    fn successfully_deserialize_query() {
+        let app = app();
+        let mut server = make_server(app.into_http_service()).unwrap();
+        let req = http::Request::get("/?msg=Hello")
+            .body(Body::empty())
+            .unwrap();
+        let res = server.simulate(req).unwrap();
+        assert_eq!(res.status(), 200);
+        let body = block_on(res.into_body().into_vec()).unwrap();
+        assert_eq!(&*body, &*b"Hello");
+    }
+
+    #[test]
+    fn unsuccessfully_deserialize_query() {
+        let app = app();
+        let mut server = make_server(app.into_http_service()).unwrap();
+        let req = http::Request::get("/").body(Body::empty()).unwrap();
+        let res = server.simulate(req).unwrap();
+        assert_eq!(res.status(), 400);
+    }
+
+    #[test]
+    fn malformatted_query() {
+        let app = app();
+        let mut server = make_server(app.into_http_service()).unwrap();
+        let req = http::Request::get("/?error=should_fail")
+            .body(Body::empty())
+            .unwrap();
+        let res = server.simulate(req).unwrap();
+        assert_eq!(res.status(), 400);
+    }
+}


### PR DESCRIPTION
This commit adds query string extraction via the `ExtractQuery` trait, implemented for `tide::Context`.

## Description
Added a module, `querystring`, which includes the `ExtractQuery` trait to help with validating and deserializing HTTP query parameters.

## Motivation and Context

Processing query parameters is a common concern of most HTTP frameworks.

## How Has This Been Tested?

Simulated requests to a Tide endpoint. This PR doesn't remove or alter existing functionality.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
