### PR TITLE
fix: sync up with nightly futures_api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2019-02-27
+  - nightly-2019-04-15
 
 before_script: |
   rustup component add rustfmt clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2019-04-15
+  - nightly-2019-04-16
 
 before_script: |
   rustup component add rustfmt clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ version = "0.1.0"
 
 [dependencies]
 cookie = "0.11"
-futures-preview = "0.3.0-alpha.13"
+futures-preview = "0.3.0-alpha.14"
 fnv = "1.0.6"
 http = "0.1"
-http-service = "0.1.4"
+http-service = "0.1.4" # TODO: update after release
 pin-utils = "0.1.0-alpha.4"
 route-recognizer = "0.1.12"
-serde = "1.0.80"
-serde_derive = "1.0.80"
-serde_json = "1.0.32"
-serde_qs = "0.4.1"
+serde = "1.0.90"
+serde_derive = "1.0.90"
+serde_json = "1.0.39"
+serde_qs = "0.4.5"
 slog = "2.4.1"
 slog-async = "2.3.0"
 slog-term = "2.4.0"
@@ -31,7 +31,7 @@ typemap = "0.3.3"
 
 [dependencies.http-service-hyper]
 optional = true
-version = "0.1.0"
+version = "0.1.0" # TODO: update after release
 
 [dependencies.multipart]
 default-features = false
@@ -45,7 +45,7 @@ hyper = ["http-service-hyper"]
 [dev-dependencies]
 basic-cookies = "0.1.3"
 juniper = "0.10.0"
-structopt = "0.2.14"
-http-service-mock = "0.1.0"
-serde = "1.0.80"
-serde_derive = "1.0.80"
+structopt = "0.2.15"
+http-service-mock = "0.1.0" # TODO: update after release
+serde = "1.0.90"
+serde_derive = "1.0.90"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cookie = "0.11"
 futures-preview = "0.3.0-alpha.14"
 fnv = "1.0.6"
 http = "0.1"
-http-service = "0.1.4" # TODO: update after release
+http-service = "0.1.5"
 pin-utils = "0.1.0-alpha.4"
 route-recognizer = "0.1.12"
 serde = "1.0.90"
@@ -31,7 +31,7 @@ typemap = "0.3.3"
 
 [dependencies.http-service-hyper]
 optional = true
-version = "0.1.0" # TODO: update after release
+version = "0.1.1"
 
 [dependencies.multipart]
 default-features = false
@@ -46,6 +46,6 @@ hyper = ["http-service-hyper"]
 basic-cookies = "0.1.3"
 juniper = "0.10.0"
 structopt = "0.2.15"
-http-service-mock = "0.1.0" # TODO: update after release
+http-service-mock = "0.1.1"
 serde = "1.0.90"
 serde_derive = "1.0.90"

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -38,7 +38,7 @@ use crate::{response::IntoResponse, Context, Response};
 /// # #![feature(futures_api)]
 /// # use core::future::Future;
 /// fn hello(_cx: tide::Context<()>) -> impl Future<Output = String> {
-///     futures::ready!(String::from("hello"))
+///     futures::future::ready(String::from("hello"))
 /// }
 ///
 /// fn main() {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -7,7 +7,7 @@ use crate::{response::IntoResponse, Context, Response};
 /// This trait is automatically implemented for `Fn` types, and so is rarely implemented
 /// directly by Tide users.
 ///
-/// In practice, endpoints are function that take a `Context<AppData>` as an argument and
+/// In practice, endpoints are functions that take a `Context<AppData>` as an argument and
 /// return a type `T` that implements [`IntoResponse`].
 ///
 /// # Examples
@@ -31,6 +31,24 @@ use crate::{response::IntoResponse, Context, Response};
 ///     app.serve("127.0.0.1:8000").unwrap()
 /// }
 /// ```
+///
+/// An endpoint with similar functionality that does not make use of the `async` keyword would look something like this:
+///
+/// ```rust, no_run
+/// # #![feature(futures_api)]
+/// # use core::future::Future;
+/// fn hello(_cx: tide::Context<()>) -> impl Future<Output = String> {
+///     futures::ready!(String::from("hello"))
+/// }
+///
+/// fn main() {
+///     let mut app = tide::App::new(());
+///     app.at("/hello").get(hello);
+///     app.serve("127.0.0.1:8000").unwrap()
+/// }
+/// ```
+///
+/// Tide routes will also accept endpoints with `Fn` signatures of this form, but using the `async` keyword has better ergonomics.
 pub trait Endpoint<AppData>: Send + Sync + 'static {
     /// The async result of `call`.
     type Fut: Future<Output = Response> + Send + 'static;

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ pub struct StringError(pub String);
 impl std::error::Error for StringError {}
 
 impl std::fmt::Display for StringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         self.0.fmt(f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 #![allow(unused_variables)]
 #![deny(nonstandard_style)]
 #![forbid(rust_2018_idioms)]
-
 // Remove this clippy bug with async await is resolved.
 // ISSUE: https://github.com/rust-lang/rust-clippy/issues/3988
 #![allow(clippy::needless_lifetimes)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,14 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(test, deny(warnings))]
-#![allow(unused_variables)]
 #![feature(futures_api, async_await, await_macro, existential_type)]
+#![allow(unused_variables)]
+#![deny(nonstandard_style)]
+#![forbid(rust_2018_idioms)]
+
+// Remove this clippy bug with async await is resolved.
+// ISSUE: https://github.com/rust-lang/rust-clippy/issues/3988
+#![allow(clippy::needless_lifetimes)]
 
 //!
 //! Welcome to Tide.


### PR DESCRIPTION
Sync up the new changes in the nightly futures_api: futures dependency to 0.3.0-alpha.14
Also, updated all patch versions of other deps, while at it.

Blocker for successful build/release: https://github.com/rustasync/http-service/pull/14