### PR TITLE
add rfc template

### DIFF
--- a/rfcs/000-template.md
+++ b/rfcs/000-template.md
@@ -1,0 +1,66 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Tracking Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the proposal.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What problems does it
+solve? What is the expected outcome?
+
+# Stakeholders
+[stakeholders]: #stakeholders
+
+* Who is affected by this RFC?
+
+* How are we soliciting feedback on this RFC from these stakeholders? Note that
+  they may not be watching the RFCs repository or even aren't directly active in
+  the Rust Async Ecosystem working group.
+
+# Detailed Explanation
+[detailed-explanation]: #detailed-explanation
+
+- Introduce and explain new concepts.
+
+- It should be reasonably clear how the proposal would be implemented.
+
+- Provide representative examples that show how this proposal would be commonly
+  used.
+
+- Corner cases should be dissected by example.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- Why should we *not* do this?
+
+# Rationale and Alternatives
+[alternatives]: #rationale-and-alternatives
+
+This is your chance to discuss your proposal in the context of the whole design
+space. This is probably the most important section!
+
+- Why is this design the best in the space of possible designs?
+
+- What other designs have been considered and what is the rationale for not
+  choosing them?
+
+- What is the impact of not doing this?
+
+# Unresolved Questions
+[unresolved]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process
+  before this gets merged?
+
+- What parts of the design do you expect to resolve through the implementation
+  of this feature?
+
+- What related issues do you consider out of scope for this RFC that could be
+  addressed in the future independently of the solution that comes out of this
+  RFC?


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds an RFC template to Tide, similar to [rustwasm's RFC template](https://github.com/rustwasm/rfcs).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When making changes to an API it can be useful to get consensus on the design first in a structured manner before moving to implementation. The Rust project has proven that filing RFCs has been a a good strategy to discuss these kinds of changes, and we're seeing a similar process work well for [`rustwasm/gloo`](https://github.com/rustwasm/gloo/pull/76) and [`crossbeam`](https://github.com/crossbeam-rs/rfcs/tree/master/text).

I've chosen to add the RFC template directly to Tide so we can discuss changes in the same repo. Having a separate RFC directory could be another option, but I feel that could be something we can  move to at a later stage if we think that's desirable. The main goal for now is to provide us with a more structured way of proposing API changes, for which this should be the right way to go.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No tests needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
