### PR TITLE
Update for futures v0.3.0-alpha.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2019-04-16
+  - nightly-2019-04-25
 
 before_script: |
   rustup component add rustfmt clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ version = "0.1.1"
 
 [dependencies]
 cookie = { version="0.11", features = ["percent-encode"] }
-futures-preview = "0.3.0-alpha.14"
+futures-preview = "0.3.0-alpha.15"
 fnv = "1.0.6"
 http = "0.1"
-http-service = "0.1.5"
+http-service = "0.2.0"
 pin-utils = "0.1.0-alpha.4"
 route-recognizer = "0.1.12"
 serde = "1.0.90"
@@ -31,7 +31,7 @@ serde_urlencoded = "0.5.5"
 
 [dependencies.http-service-hyper]
 optional = true
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies.multipart]
 default-features = false
@@ -46,5 +46,5 @@ hyper = ["http-service-hyper"]
 basic-cookies = "0.1.3"
 juniper = "0.10.0"
 structopt = "0.2.15"
-http-service-mock = "0.1.1"
+http-service-mock = "0.2.0"
 serde = { version = "1.0.90", features = ["derive"] }

--- a/examples/body_types.rs
+++ b/examples/body_types.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, futures_api, await_macro)]
+#![feature(async_await, await_macro)]
 
 use serde::{Deserialize, Serialize};
 use tide::{

--- a/examples/catch_all.rs
+++ b/examples/catch_all.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, futures_api)]
+#![feature(async_await)]
 
 use tide::Context;
 

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, futures_api)]
+#![feature(async_await)]
 
 use cookie::Cookie;
 use tide::{cookies::CookiesExt, middleware::CookiesMiddleware, Context};

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -3,7 +3,7 @@
 //
 // [the Juniper book]: https://graphql-rust.github.io/
 
-#![feature(async_await, futures_api, await_macro)]
+#![feature(async_await, await_macro)]
 
 use http::status::StatusCode;
 use juniper::graphql_object;

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, futures_api, await_macro)]
+#![feature(async_await, await_macro)]
 
 use http::status::StatusCode;
 use serde::{Deserialize, Serialize};

--- a/examples/multipart-form/main.rs
+++ b/examples/multipart-form/main.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, futures_api, await_macro)]
+#![feature(async_await, await_macro)]
 
 use serde::{Deserialize, Serialize};
 use std::io::Read;

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,4 +1,4 @@
-use futures::future::{Future, FutureObj};
+use futures::future::{BoxFuture, Future};
 
 use crate::{response::IntoResponse, Context, Response};
 
@@ -58,7 +58,7 @@ pub trait Endpoint<AppData>: Send + Sync + 'static {
 }
 
 pub(crate) type DynEndpoint<AppData> =
-    dyn (Fn(Context<AppData>) -> FutureObj<'static, Response>) + 'static + Send + Sync;
+    dyn (Fn(Context<AppData>) -> BoxFuture<'static, Response>) + 'static + Send + Sync;
 
 impl<AppData, F: Send + Sync + 'static, Fut> Endpoint<AppData> for F
 where
@@ -66,7 +66,7 @@ where
     Fut: Future + Send + 'static,
     Fut::Output: IntoResponse,
 {
-    type Fut = FutureObj<'static, Response>;
+    type Fut = BoxFuture<'static, Response>;
     fn call(&self, cx: Context<AppData>) -> Self::Fut {
         let fut = (self)(cx);
         box_async! {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,11 @@
+use core::pin::Pin;
+use futures::future::Future;
 use http::{HttpTryFrom, Response, StatusCode};
 use http_service::Body;
 
 use crate::response::IntoResponse;
 
-pub(crate) type BoxTryFuture<T> = futures::future::FutureObj<'static, EndpointResult<T>>;
+pub(crate) type BoxTryFuture<T> = Pin<Box<dyn Future<Output = EndpointResult<T>> + Send + 'static>>;
 
 /// A convenient `Result` instantiation appropriate for most endpoints.
 pub type EndpointResult<T = Response<Body>> = Result<T, Error>;

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -1,4 +1,3 @@
-use futures::future::FutureObj;
 use http_service::Body;
 use multipart::server::Multipart;
 use std::io::Cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(test, deny(warnings))]
-#![feature(futures_api, async_await, await_macro, existential_type)]
+#![feature(async_await, await_macro, existential_type)]
 #![allow(unused_variables)]
 #![deny(nonstandard_style, rust_2018_idioms, future_incompatible)]
 // TODO: Remove this after clippy bug due to async await is resolved.
@@ -18,7 +18,7 @@
 
 macro_rules! box_async {
     {$($t:tt)*} => {
-        FutureObj::new(Box::new(async move { $($t)* }))
+        ::futures::future::FutureExt::boxed(async move { $($t)* })
     };
 }
 

--- a/src/middleware/cookies.rs
+++ b/src/middleware/cookies.rs
@@ -1,5 +1,5 @@
 use crate::cookies::CookieData;
-use futures::future::FutureObj;
+use futures::future::BoxFuture;
 use http::header::HeaderValue;
 
 use crate::{
@@ -30,7 +30,7 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for CookiesMiddleware {
         &'a self,
         mut cx: Context<Data>,
         next: Next<'a, Data>,
-    ) -> FutureObj<'a, Response> {
+    ) -> BoxFuture<'a, Response> {
         box_async! {
             let cookie_data = cx
                 .extensions_mut()

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -1,4 +1,4 @@
-use futures::future::FutureObj;
+use futures::future::BoxFuture;
 
 use http::{
     header::{HeaderValue, IntoHeaderName},
@@ -40,7 +40,7 @@ impl DefaultHeaders {
 }
 
 impl<Data: Send + Sync + 'static> Middleware<Data> for DefaultHeaders {
-    fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> FutureObj<'a, Response> {
+    fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> BoxFuture<'a, Response> {
         box_async! {
             let mut res = await!(next.run(cx));
 

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -2,7 +2,7 @@ use slog::{info, o, Drain};
 use slog_async;
 use slog_term;
 
-use futures::future::FutureObj;
+use futures::future::BoxFuture;
 
 use crate::{
     middleware::{Middleware, Next},
@@ -35,7 +35,7 @@ impl Default for RootLogger {
 /// Stores information during request phase and logs information once the response
 /// is generated.
 impl<Data: Send + Sync + 'static> Middleware<Data> for RootLogger {
-    fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> FutureObj<'a, Response> {
+    fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> BoxFuture<'a, Response> {
         box_async! {
             let path = cx.uri().path().to_owned();
             let method = cx.method().as_str().to_owned();

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,4 +1,4 @@
-#![feature(futures_api, async_await)]
+#![feature(async_await)]
 
 use futures::executor::block_on;
 use http_service::Body;


### PR DESCRIPTION
Remove FutureObj usage and futures_api feature

Blocked on an http-service release with https://github.com/rustasync/http-service/pull/23

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.