### PR TITLE
Middleware-based compression and decompression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_script: |
   rustup component add rustfmt clippy
 script: |
   cargo fmt --all -- --check &&
-  cargo clippy --all -- -D clippy::all &&
+  cargo clippy --all --all-features -- -D clippy::all &&
   cargo build --no-default-features --verbose &&
-  cargo build --all --verbose &&
-  cargo test  --all --verbose
+  cargo build --all --all-features --verbose &&
+  cargo test --all --all-features --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "tide",
+    "tide-compression",
     "examples",
 ]
 

--- a/tide-compression/Cargo.toml
+++ b/tide-compression/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+authors = [
+    "Tide Developers",
+]
+description = "Compression-related middleware for Tide"
+documentation = "https://docs.rs/tide-compression"
+keywords = ["tide", "web", "async", "middleware", "compression"]
+categories = ["network-programming", "compression", "asynchronous"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+name = "tide-compression"
+readme = "README.md"
+repository = "https://github.com/rustasync/tide"
+version = "0.1.0"
+
+[dependencies]
+tide = { path = "../tide" }
+accept-encoding = "0.2.0-alpha.2"
+bytes = "0.4.12"
+futures-preview = "0.3.0-alpha.16"
+http = "0.1"
+http-service = "0.2.0"
+
+[dependencies.async-compression]
+default-features = false
+features = ["stream", "gzip", "zlib", "brotli", "zstd"]
+version = "0.1.0-alpha.1"
+
+[dev-dependencies]
+http-service-mock = "0.2.0"

--- a/tide-compression/README.md
+++ b/tide-compression/README.md
@@ -1,0 +1,16 @@
+# tide-compression
+
+This crate provides compression-related middleware for Tide.
+
+## Examples
+
+Examples are in the `/examples` folder of this crate.
+
+__Simple Example__
+
+You can test the simple example by running `cargo run --example simple` while in this crate's directory, and then running either of the following commands:
+
+```console
+$ curl http://127.0.0.1:8000/ -v
+$ curl http://127.0.0.1:8000/echo -v -d "why hello there"
+```

--- a/tide-compression/README.md
+++ b/tide-compression/README.md
@@ -12,5 +12,5 @@ You can test the simple example by running `cargo run --example simple` while in
 
 ```console
 $ curl http://127.0.0.1:8000/ -v
-$ curl http://127.0.0.1:8000/echo -v -d "why hello there"
+$ echo 'why hello there' | gzip | curl -v --compressed -H 'Content-Encoding: gzip' 'http://127.0.0.1:8000/echo' --data-binary @-
 ```

--- a/tide-compression/examples/simple.rs
+++ b/tide-compression/examples/simple.rs
@@ -18,5 +18,5 @@ pub fn main() {
     app.at("/echo").post(echo_bytes);
     app.middleware(Compression::with_default(Encoding::Brotli));
     app.middleware(Decompression::new());
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/tide-compression/examples/simple.rs
+++ b/tide-compression/examples/simple.rs
@@ -1,0 +1,22 @@
+#![feature(async_await)]
+use tide::{App, Context};
+use tide_compression::{Compression, Decompression, Encoding};
+
+// Returns a portion of the lorem ipsum text.
+async fn lorem_ipsum(_cx: Context<()>) -> String {
+    String::from("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+}
+
+// Echoes the request body in bytes.
+async fn echo_bytes(mut cx: Context<()>) -> Vec<u8> {
+    cx.body_bytes().await.unwrap()
+}
+
+pub fn main() {
+    let mut app = App::new();
+    app.at("/").get(lorem_ipsum);
+    app.at("/echo").post(echo_bytes);
+    app.middleware(Compression::with_default(Encoding::Brotli));
+    app.middleware(Decompression::new());
+    app.serve("127.0.0.1:8000").unwrap();
+}

--- a/tide-compression/src/lib.rs
+++ b/tide-compression/src/lib.rs
@@ -1,0 +1,423 @@
+#![cfg_attr(feature = "nightly", deny(missing_docs))]
+#![cfg_attr(feature = "nightly", feature(external_doc))]
+#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
+#![cfg_attr(test, deny(warnings))]
+#![feature(async_await)]
+#![deny(
+    nonstandard_style,
+    rust_2018_idioms,
+    future_incompatible,
+    missing_debug_implementations
+)]
+
+pub use accept_encoding::Encoding;
+use async_compression::stream;
+use futures::future::BoxFuture;
+use http::{header::CONTENT_ENCODING, status::StatusCode, HeaderMap};
+use http_service::{Body, Request};
+use tide::{
+    middleware::{Middleware, Next},
+    response::IntoResponse,
+    Context, Error, Response,
+};
+
+macro_rules! box_async {
+    {$($t:tt)*} => {
+        ::futures::future::FutureExt::boxed(async move { $($t)* })
+    };
+}
+
+/// Encode settings for the compression middleware.
+///
+/// This can be modified in the case that you want more control over the speed or quality of compression.
+///
+/// For more information on how to configure each of these settings, see the async-compression crate.
+#[derive(Debug)]
+pub struct EncodeSettings {
+    /// Settings for gzip compression.
+    pub gzip: async_compression::flate2::Compression,
+    /// Settings for deflate compression.
+    pub deflate: async_compression::flate2::Compression,
+    /// Settings for brotli compression. Ranges from 0-11. (default: `11`)
+    pub brotli: u32,
+    /// Settings for zstd compression. Ranges from 1-21. (default: `3`)
+    pub zstd: i32,
+}
+
+impl Default for EncodeSettings {
+    fn default() -> Self {
+        Self {
+            gzip: Default::default(),
+            deflate: Default::default(),
+            brotli: 11,
+            zstd: 3,
+        }
+    }
+}
+
+/// Middleware for automatically handling outgoing response compression.
+///
+/// This middleware currently supports HTTP compression using `gzip`, `deflate`, `br`, and `zstd`.
+#[derive(Debug)]
+pub struct Compression {
+    default_encoding: Encoding,
+    settings: EncodeSettings,
+}
+
+impl Default for Compression {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Compression {
+    /// Creates a new Compression middleware. The default encoding is [`Encoding::Identity`] (no encoding).
+    pub fn new() -> Self {
+        Self {
+            default_encoding: Encoding::Identity,
+            settings: Default::default(),
+        }
+    }
+
+    /// Creates a new Compression middleware with a provided default encoding.
+    ///
+    /// This encoding will be selected if the client has not set the `Accept-Encoding` header or `*` is set as the most preferred encoding.
+    pub fn with_default(default_encoding: Encoding) -> Self {
+        Self {
+            default_encoding,
+            settings: Default::default(),
+        }
+    }
+
+    /// Accesses a mutable handle to this middleware's [`EncodeSettings`].
+    ///
+    /// This will allow you to configure this middleware's settings.
+    pub fn settings_mut(&mut self) -> &mut EncodeSettings {
+        &mut self.settings
+    }
+
+    fn preferred_encoding(&self, headers: &HeaderMap) -> Result<Encoding, Error> {
+        let encoding = match accept_encoding::parse(headers) {
+            Ok(encoding) => encoding,
+            Err(_) => return Err(Error::from(StatusCode::BAD_REQUEST)),
+        };
+        Ok(encoding.unwrap_or(self.default_encoding))
+    }
+
+    /// Consumes the response and returns an encoded version of it.
+    fn encode(&self, mut res: Response, encoding: Encoding) -> Response {
+        if res.headers().get(CONTENT_ENCODING).is_some() || encoding == Encoding::Identity {
+            return res; // avoid double-encoding a given response
+        }
+        let body = std::mem::replace(res.body_mut(), Body::empty());
+        match encoding {
+            Encoding::Gzip => {
+                let stream = stream::GzipEncoder::new(body, self.settings.gzip);
+                *res.body_mut() = Body::from_stream(stream);
+            }
+            Encoding::Deflate => {
+                let stream = stream::ZlibEncoder::new(body, self.settings.deflate);
+                *res.body_mut() = Body::from_stream(stream);
+            }
+            Encoding::Brotli => {
+                let stream = stream::BrotliEncoder::new(body, self.settings.brotli);
+                *res.body_mut() = Body::from_stream(stream);
+            }
+            Encoding::Zstd => {
+                let stream = stream::ZstdEncoder::new(body, self.settings.zstd);
+                *res.body_mut() = Body::from_stream(stream);
+            }
+            Encoding::Identity => unreachable!(),
+        };
+        res.headers_mut()
+            .append(CONTENT_ENCODING, encoding.to_header_value());
+        res
+    }
+}
+
+impl<Data: Send + Sync + 'static> Middleware<Data> for Compression {
+    fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> BoxFuture<'a, Response> {
+        box_async! {
+            let encoding = match self.preferred_encoding(cx.headers()) {
+                Ok(encoding) => encoding,
+                Err(e) => return e.into_response(),
+            };
+            let res = next.run(cx).await;
+            self.encode(res, encoding)
+        }
+    }
+}
+
+/// Middleware for handling incoming request decompression.
+///
+/// This middleware currently supports HTTP decompression under the `gzip`, `deflate`, `br`, and `zstd` algorithms.
+#[derive(Debug, Default)]
+pub struct Decompression {}
+
+impl Decompression {
+    /// Creates a new Decompression middleware.
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn parse_encoding(s: &str) -> Result<Encoding, Error> {
+        match s {
+            "gzip" => Ok(Encoding::Gzip),
+            "deflate" => Ok(Encoding::Deflate),
+            "br" => Ok(Encoding::Brotli),
+            "zstd" => Ok(Encoding::Zstd),
+            "identity" => Ok(Encoding::Identity),
+            _ => Err(Error::from(StatusCode::UNSUPPORTED_MEDIA_TYPE)),
+        }
+    }
+
+    fn decode(&self, req: &mut Request) -> Result<(), Error> {
+        let encodings = if let Some(hval) = req.headers().get(CONTENT_ENCODING) {
+            let hval = match hval.to_str() {
+                Ok(hval) => hval,
+                Err(_) => return Err(Error::from(StatusCode::BAD_REQUEST)),
+            };
+            hval.split(',')
+                .map(str::trim)
+                .rev() // apply decodings in reverse order
+                .map(Decompression::parse_encoding)
+                .collect::<Result<Vec<Encoding>, Error>>()?
+        } else {
+            return Ok(());
+        };
+
+        for encoding in encodings {
+            match encoding {
+                Encoding::Gzip => {
+                    let body = std::mem::replace(req.body_mut(), Body::empty());
+                    let stream = stream::GzipDecoder::new(body);
+                    *req.body_mut() = Body::from_stream(stream);
+                }
+                Encoding::Deflate => {
+                    let body = std::mem::replace(req.body_mut(), Body::empty());
+                    let stream = stream::ZlibDecoder::new(body);
+                    *req.body_mut() = Body::from_stream(stream);
+                }
+                Encoding::Brotli => {
+                    let body = std::mem::replace(req.body_mut(), Body::empty());
+                    let stream = stream::BrotliDecoder::new(body);
+                    *req.body_mut() = Body::from_stream(stream);
+                }
+                Encoding::Zstd => {
+                    let body = std::mem::replace(req.body_mut(), Body::empty());
+                    let stream = stream::ZstdDecoder::new(body);
+                    *req.body_mut() = Body::from_stream(stream);
+                }
+                Encoding::Identity => (),
+            }
+        }
+
+        // strip the content-encoding header
+        req.headers_mut().remove(CONTENT_ENCODING).unwrap();
+
+        Ok(())
+    }
+}
+
+impl<Data: Send + Sync + 'static> Middleware<Data> for Decompression {
+    fn handle<'a>(
+        &'a self,
+        mut cx: Context<Data>,
+        next: Next<'a, Data>,
+    ) -> BoxFuture<'a, Response> {
+        box_async! {
+            match self.decode(cx.request_mut()) {
+                Ok(_) => (),
+                Err(e) => return e.into_response(),
+            };
+            next.run(cx).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_compression::flate2;
+    use bytes::Bytes;
+    use futures::{
+        executor::{block_on, block_on_stream},
+        stream::StreamExt,
+    };
+    use http::header::ACCEPT_ENCODING;
+    use http_service::Body;
+    use http_service_mock::make_server;
+
+    async fn lorem_ipsum(_cx: Context<()>) -> String {
+        String::from(r#"
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam rutrum et risus sed egestas. Maecenas dapibus enim a posuere
+            semper. Cras venenatis et turpis quis aliquam. Suspendisse eget risus in libero tristique consectetur. Ut ut risus cursus, scelerisque
+            enim ac, tempus tellus. Vestibulum ac porta felis. Aenean fringilla posuere felis, in blandit enim tristique ut. Sed elementum iaculis
+            enim eu commodo.
+        "#)
+    }
+
+    fn lorem_ipsum_bytes() -> Vec<u8> {
+        String::from(r#"
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam rutrum et risus sed egestas. Maecenas dapibus enim a posuere
+            semper. Cras venenatis et turpis quis aliquam. Suspendisse eget risus in libero tristique consectetur. Ut ut risus cursus, scelerisque
+            enim ac, tempus tellus. Vestibulum ac porta felis. Aenean fringilla posuere felis, in blandit enim tristique ut. Sed elementum iaculis
+            enim eu commodo.
+        "#).into_bytes()
+    }
+
+    // Echoes the request body in bytes.
+    async fn echo_bytes(mut cx: Context<()>) -> Vec<u8> {
+        cx.body_bytes().await.unwrap()
+    }
+
+    // Generates the app.
+    fn app() -> tide::App<()> {
+        let mut app = tide::App::new();
+        app.at("/").get(lorem_ipsum);
+        app.at("/echo").post(echo_bytes);
+        app.middleware(Compression::new());
+        app.middleware(Decompression::new());
+        app
+    }
+
+    // Generates a response given a string that represents the Accept-Encoding header value.
+    fn get_encoded_response(hval: &str) -> Response {
+        let app = app();
+        let mut server = make_server(app.into_http_service()).unwrap();
+        let req = http::Request::get("/")
+            .header(ACCEPT_ENCODING, hval)
+            .body(Body::empty())
+            .unwrap();
+        let res = server.simulate(req).unwrap();
+        res
+    }
+
+    // Generates a decoded response given a request body and the header value representing its encoding.
+    fn get_decoded_response(body: Body, hval: &str) -> Response {
+        let app = app();
+        let mut server = make_server(app.into_http_service()).unwrap();
+        let req = http::Request::post("/echo")
+            .header(CONTENT_ENCODING, hval)
+            .body(body)
+            .unwrap();
+        let res = server.simulate(req).unwrap();
+        res
+    }
+
+    #[test]
+    fn compressed_gzip_response() {
+        let res = get_encoded_response("gzip");
+        assert_eq!(res.status(), 200);
+        let body = res.into_body();
+        let stream = stream::GzipDecoder::new(body);
+        let decompressed_body: Vec<u8> = block_on_stream(stream)
+            .map(Result::unwrap)
+            .flatten()
+            .collect();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(decompressed_body, lorem_ipsum);
+    }
+
+    #[test]
+    fn compressed_deflate_response() {
+        let res = get_encoded_response("deflate");
+        assert_eq!(res.status(), 200);
+        let body = res.into_body();
+        let stream = stream::ZlibDecoder::new(body);
+        let decompressed_body: Vec<u8> = block_on_stream(stream)
+            .map(Result::unwrap)
+            .flatten()
+            .collect();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(decompressed_body, lorem_ipsum);
+    }
+
+    #[test]
+    fn compressed_brotli_response() {
+        let res = get_encoded_response("br");
+        assert_eq!(res.status(), 200);
+        let body = res.into_body();
+        let stream = stream::BrotliDecoder::new(body);
+        let decompressed_body: Vec<u8> = block_on_stream(stream)
+            .map(Result::unwrap)
+            .flatten()
+            .collect();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(decompressed_body, lorem_ipsum);
+    }
+
+    #[test]
+    fn compressed_zstd_response() {
+        let res = get_encoded_response("zstd");
+        assert_eq!(res.status(), 200);
+        let body = res.into_body();
+        let stream = stream::ZstdDecoder::new(body);
+        let decompressed_body: Vec<u8> = block_on_stream(stream)
+            .map(Result::unwrap)
+            .flatten()
+            .collect();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(decompressed_body, lorem_ipsum);
+    }
+
+    #[test]
+    fn decompressed_gzip_response() {
+        let lorem_ipsum = lorem_ipsum_bytes();
+        let req_body = Body::from_stream(stream::GzipEncoder::new(
+            futures::stream::iter(vec![lorem_ipsum])
+                .map(Bytes::from)
+                .map(Ok),
+            flate2::Compression::default(),
+        ));
+        let res = get_decoded_response(req_body, "gzip");
+        let body = block_on(res.into_body().into_vec()).unwrap();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(body, lorem_ipsum);
+    }
+
+    #[test]
+    fn decompressed_deflate_response() {
+        let lorem_ipsum = lorem_ipsum_bytes();
+        let req_body = Body::from_stream(stream::ZlibEncoder::new(
+            futures::stream::iter(vec![lorem_ipsum])
+                .map(Bytes::from)
+                .map(Ok),
+            flate2::Compression::default(),
+        ));
+        let res = get_decoded_response(req_body, "deflate");
+        let body = block_on(res.into_body().into_vec()).unwrap();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(body, lorem_ipsum);
+    }
+
+    #[test]
+    fn decompressed_brotli_response() {
+        let lorem_ipsum = lorem_ipsum_bytes();
+        let req_body = Body::from_stream(stream::BrotliEncoder::new(
+            futures::stream::iter(vec![lorem_ipsum])
+                .map(Bytes::from)
+                .map(Ok),
+            11,
+        ));
+        let res = get_decoded_response(req_body, "br");
+        let body = block_on(res.into_body().into_vec()).unwrap();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(body, lorem_ipsum);
+    }
+
+    #[test]
+    fn decompressed_zstd_response() {
+        let lorem_ipsum = lorem_ipsum_bytes();
+        let req_body = Body::from_stream(stream::ZstdEncoder::new(
+            futures::stream::iter(vec![lorem_ipsum])
+                .map(Bytes::from)
+                .map(Ok),
+            3,
+        ));
+        let res = get_decoded_response(req_body, "zstd");
+        let body = block_on(res.into_body().into_vec()).unwrap();
+        let lorem_ipsum = lorem_ipsum_bytes();
+        assert_eq!(body, lorem_ipsum);
+    }
+}

--- a/tide/src/context.rs
+++ b/tide/src/context.rs
@@ -55,6 +55,11 @@ impl<State> Context<State> {
         &self.request
     }
 
+    /// Access a mutable handle to the entire request.
+    pub fn request_mut(&mut self) -> &mut http_service::Request {
+        &mut self.request
+    }
+
     ///  Access app-global data.
     pub fn state(&self) -> &State {
         &self.state


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provides compression middleware for outgoing HTTP responses and decompression middleware for incoming HTTP requests.

## Description
<!--- Describe your changes in detail -->
These two middlewares do the following:

* Automatically handle incoming request decompression for `Content-Encoding` headers that contain one or more applications of `gzip`, `deflate`, `br`, or `zstd`.
* Encode outgoing responses with preferred encoding behavior for any incoming request with a valid `Accept-Encoding` header.
* Allow one to define compression levels for each compression algorithm available.

The decompression middleware actually depends on getting a mutable handle on the request from the context, hence why a new function was added [here](https://github.com/rustasync/tide/blob/b6bcbde42007bf3e2a7c45b38309431c0a918971/src/context.rs#L59-L61).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This closes https://github.com/rustasync/tide/issues/26.

Tide currently has no way of handling encoded requests or handling outgoing request compression. This middleware is one approach to solve that problem, although there exist a multitude of approaches that may work. This middleware may also serve as a point of discussion for https://github.com/rustasync/team/issues/52.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are written! They're not very thorough, but that's because it's only to test their functionality. More rigorous tests for each of the stream encoders/decoders are in the async-compression crate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
