### PR TITLE
add strict debug impl requirements

### DIFF
--- a/examples/body_types.rs
+++ b/examples/body_types.rs
@@ -13,24 +13,28 @@ struct Message {
     contents: String,
 }
 
+#[allow(unused_mut)] // Workaround clippy bug
 async fn echo_string(mut cx: Context<()>) -> String {
     let msg = cx.body_string().await.unwrap();
     println!("String: {}", msg);
     msg
 }
 
+#[allow(unused_mut)] // Workaround clippy bug
 async fn echo_bytes(mut cx: Context<()>) -> Vec<u8> {
     let msg = cx.body_bytes().await.unwrap();
     println!("Bytes: {:?}", msg);
     msg
 }
 
+#[allow(unused_mut)] // Workaround clippy bug
 async fn echo_json(mut cx: Context<()>) -> EndpointResult {
     let msg = cx.body_json().await.client_err()?;
     println!("JSON: {:?}", msg);
     Ok(response::json(msg))
 }
 
+#[allow(unused_mut)] // Workaround clippy bug
 async fn echo_form(mut cx: Context<()>) -> EndpointResult {
     let msg = cx.body_form().await?;
     println!("Form: {:?}", msg);

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -8,9 +8,13 @@ use tide::{cookies::CookiesExt, middleware::CookiesMiddleware, Context};
 async fn retrieve_cookie(mut cx: Context<()>) -> String {
     format!("hello cookies: {:?}", cx.get_cookie("hello").unwrap())
 }
+
+#[allow(unused_mut)] // Workaround clippy bug
 async fn set_cookie(mut cx: Context<()>) {
     cx.set_cookie(Cookie::new("hello", "world")).unwrap();
 }
+
+#[allow(unused_mut)] // Workaround clippy bug
 async fn remove_cookie(mut cx: Context<()>) {
     cx.remove_cookie(Cookie::named("hello")).unwrap();
 }

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -39,11 +39,13 @@ impl Database {
     }
 }
 
+#[allow(unused_mut)] // Workaround clippy bug
 async fn new_message(mut cx: Context<Database>) -> EndpointResult<String> {
     let msg = cx.body_json().await.client_err()?;
     Ok(cx.state().insert(msg).to_string())
 }
 
+#[allow(unused_mut)] // Workaround clippy bug
 async fn set_message(mut cx: Context<Database>) -> EndpointResult<()> {
     let msg = cx.body_json().await.client_err()?;
     let id = cx.param("id").client_err()?;

--- a/examples/multipart-form/main.rs
+++ b/examples/multipart-form/main.rs
@@ -11,6 +11,7 @@ struct Message {
     file: Option<String>,
 }
 
+#[allow(unused_mut)] // Workaround clippy bug
 async fn upload_file(mut cx: Context<()>) -> EndpointResult {
     // https://stackoverflow.com/questions/43424982/how-to-parse-multipart-forms-using-abonander-multipart-with-rocket
     let mut message = Message {

--- a/src/app.rs
+++ b/src/app.rs
@@ -127,6 +127,7 @@ use crate::{
 /// }
 /// ```
 
+#[allow(missing_debug_implementations)]
 pub struct App<State> {
     router: Router<State>,
     middleware: Vec<Arc<dyn Middleware<State>>>,
@@ -252,6 +253,7 @@ impl<State: Send + Sync + 'static> App<State> {
 /// This type is useful only in conjunction with the [`HttpService`] trait,
 /// i.e. for hosting a Tide app within some custom HTTP server.
 #[derive(Clone)]
+#[allow(missing_debug_implementations)]
 pub struct Server<State> {
     router: Arc<Router<State>>,
     data: Arc<State>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,6 +10,7 @@ use std::{str::FromStr, sync::Arc};
 ///
 /// Contexts also provide *extensions*, a type map primarily used for low-level
 /// communication between middleware and endpoints.
+#[derive(Debug)]
 pub struct Context<State> {
     state: Arc<State>,
     request: http_service::Request,

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,7 @@ macro_rules! err_fmt {
 }
 
 /// A generic endpoint error, which can be converted into a response.
+#[derive(Debug)]
 pub struct Error {
     resp: Response<Body>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,12 @@
 #![cfg_attr(test, deny(warnings))]
 #![feature(async_await, existential_type)]
 #![allow(unused_variables)]
-#![deny(nonstandard_style, rust_2018_idioms, future_incompatible)]
+#![deny(
+    nonstandard_style,
+    rust_2018_idioms,
+    future_incompatible,
+    missing_debug_implementations
+)]
 // TODO: Remove this after clippy bug due to async await is resolved.
 // ISSUE: https://github.com/rust-lang/rust-clippy/issues/3988
 #![allow(clippy::needless_lifetimes)]

--- a/src/middleware/cookies.rs
+++ b/src/middleware/cookies.rs
@@ -16,7 +16,7 @@ use crate::{
 /// is processed by endpoints and other middlewares, all the added and removed cookies are set on
 /// on the response. You will need to add this middle before any other middlewares that might need
 /// to access Cookies.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct CookiesMiddleware {}
 
 impl CookiesMiddleware {

--- a/src/middleware/cookies.rs
+++ b/src/middleware/cookies.rs
@@ -72,17 +72,23 @@ mod tests {
     static COOKIE_NAME: &str = "testCookie";
 
     /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
+    #[allow(unused_mut)] // Workaround clippy bug    
     async fn retrieve_cookie(mut cx: Context<()>) -> String {
         format!("{}", cx.get_cookie(COOKIE_NAME).unwrap().unwrap().value())
     }
+
+    #[allow(unused_mut)] // Workaround clippy bug
     async fn set_cookie(mut cx: Context<()>) {
         cx.set_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"))
             .unwrap();
     }
+
+    #[allow(unused_mut)] // Workaround clippy bug
     async fn remove_cookie(mut cx: Context<()>) {
         cx.remove_cookie(Cookie::named(COOKIE_NAME)).unwrap();
     }
 
+    #[allow(unused_mut)] // Workaround clippy bug
     async fn set_multiple_cookie(mut cx: Context<()>) {
         cx.set_cookie(Cookie::new("C1", "V1")).unwrap();
         cx.set_cookie(Cookie::new("C2", "V2")).unwrap();

--- a/src/middleware/cookies.rs
+++ b/src/middleware/cookies.rs
@@ -72,7 +72,7 @@ mod tests {
     static COOKIE_NAME: &str = "testCookie";
 
     /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
-    #[allow(unused_mut)] // Workaround clippy bug    
+    #[allow(unused_mut)] // Workaround clippy bug
     async fn retrieve_cookie(mut cx: Context<()>) -> String {
         format!("{}", cx.get_cookie(COOKIE_NAME).unwrap().unwrap().value())
     }

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Middleware for providing a set of default headers for all responses.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct DefaultHeaders {
     headers: HeaderMap,
 }

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 /// Root logger for Tide. Wraps over logger provided by slog.SimpleLogger
+#[derive(Debug)]
 pub struct RootLogger {
     // drain: dyn slog::Drain,
     inner_logger: slog::Logger,

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -25,6 +25,7 @@ where
 }
 
 /// The remainder of a middleware chain, including the endpoint.
+#[allow(missing_debug_implementations)]
 pub struct Next<'a, State> {
     pub(crate) endpoint: &'a DynEndpoint<State>,
     pub(crate) next_middleware: &'a [Arc<dyn Middleware<State>>],

--- a/src/response.rs
+++ b/src/response.rs
@@ -101,6 +101,7 @@ impl<T: Send + Into<Body>> IntoResponse for http::Response<T> {
 }
 
 /// A response type that modifies the status code.
+#[derive(Debug)]
 pub struct WithStatus<R> {
     inner: R,
     status: http::status::StatusCode,

--- a/src/route.rs
+++ b/src/route.rs
@@ -8,6 +8,7 @@ use crate::{router::Router, Endpoint};
 /// `nest`, it can be used to set up a subrouter.
 ///
 /// [`App::at`]: ./struct.App.html#method.at
+#[allow(missing_debug_implementations)]
 pub struct Route<'a, State> {
     router: &'a mut Router<State>,
     path: String,

--- a/src/router.rs
+++ b/src/router.rs
@@ -12,6 +12,7 @@ use crate::{
 ///
 /// Internally, we have a separate state machine per http method; indexing
 /// by the method first allows the table itself to be more efficient.
+#[allow(missing_debug_implementations)]
 pub(crate) struct Router<State> {
     method_map: FnvHashMap<http::Method, MethodRouter<Box<DynEndpoint<State>>>>,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add missing `Debug` impls
- Enforce `missing_debug_implementations`
- Add `#[allow(missing_debug_implementations)]` currently, in places where Debug impls may not apply, or ones which probably need a proper manual Debug impl in the future

## Motivation and Context
`Debug` impl is often required by base cases in Rust (say `Result` for `unwrap`/`unwrap_err`) Currently the lack of `Debug` impl on structs like `Error` ends up causing difficultly in usage.  This lint makes sure we avoid it in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
