### PR TITLE
Change App constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Ecosystem WG, and **not ready for production use yet**.
 #![feature(async_await)]
 
 fn main() -> Result<(), std::io::Error> {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
     app.at("/").get(async move |_| "Hello, world!");
     Ok(app.serve("127.0.0.1:8000")?)
 }

--- a/README.md
+++ b/README.md
@@ -51,11 +51,14 @@
 </div>
 
 ## About
+
 A modular web framework built around async/await. It's actively being developed by the Rust Async
-Ecosystem WG, and __not ready for production use yet__.
+Ecosystem WG, and **not ready for production use yet**.
 
 ## Examples
-__Hello World__
+
+**Hello World**
+
 ```rust
 #![feature(async_await)]
 
@@ -66,7 +69,8 @@ fn main() -> Result<(), std::io::Error> {
 }
 ```
 
-__More Examples__
+**More Examples**
+
 - [Hello World](https://github.com/rustasync/tide/tree/master/examples/hello.rs)
 - [Messages](https://github.com/rustasync/tide/blob/master/examples/messages.rs)
 - [Body Types](https://github.com/rustasync/tide/blob/master/examples/body_types.rs)
@@ -77,6 +81,7 @@ __More Examples__
 - [GraphQL](https://github.com/rustasync/tide/tree/master/examples/graphql.rs)
 
 ## Resources
+
 Read about the design here:
 
 - [Rising Tide: building a modular web framework in the open](https://rustasync.github.io/team/2018/09/11/tide.html)
@@ -86,18 +91,18 @@ Read about the design here:
 
 ### Supported Rust Versions
 
-Tide is built against the latest Rust nightly releases and as such, due to it's use of `std` futures, 
+Tide is built against the latest Rust nightly releases and as such, due to it's use of `std` futures,
 it has the following specific breakpoints that align with std future API changes:
 
-Tide | Rust
---- | ---
-&le; v0.1.0 | &le; nightly-2019-04-07
-&ge; v0.1.1 | &ge; nightly-2019-04-08
-
+| Tide        | Rust                    |
+| ----------- | ----------------------- |
+| &le; v0.1.0 | &le; nightly-2019-04-07 |
+| &ge; v0.1.1 | &ge; nightly-2019-04-08 |
 
 _**Note:** Since these are due to changes in `std`, projects with dependencies that use conflicting versions of `std::futures` will not build successfully._
 
 ## Contributing
+
 Want to join us? Check out our [The "Contributing" section of the
 guide][contributing] and take a look at some of these issues:
 
@@ -105,19 +110,22 @@ guide][contributing] and take a look at some of these issues:
 - [Issues labeled "help wanted"][help-wanted]
 
 #### Conduct
+
 The Tide project adheres to the [Contributor Covenant Code of
-Conduct](https://github.com/rustasync/tide/blob/master/.github/CODE_OF_CONDUCT.md).  This
+Conduct](https://github.com/rustasync/tide/blob/master/.github/CODE_OF_CONDUCT.md). This
 describes the minimum behavior expected from all contributors.
 
 ## License
+
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 
 #### Contribution
+
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.

--- a/examples/body_types.rs
+++ b/examples/body_types.rs
@@ -38,7 +38,7 @@ async fn echo_form(mut cx: Context<()>) -> EndpointResult {
 }
 
 fn main() {
-    let mut app = App::new(());
+    let mut app = App::new();
 
     app.at("/echo/string").post(echo_string);
     app.at("/echo/bytes").post(echo_bytes);

--- a/examples/catch_all.rs
+++ b/examples/catch_all.rs
@@ -8,7 +8,7 @@ async fn echo_path(cx: Context<()>) -> String {
 }
 
 fn main() {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
     app.at("/echo_path/*path").get(echo_path);
     app.serve("127.0.0.1:8000").unwrap();
 }

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -16,7 +16,7 @@ async fn remove_cookie(mut cx: Context<()>) {
 }
 
 fn main() {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
     app.middleware(CookiesMiddleware::new());
 
     app.at("/").get(retrieve_cookie);

--- a/examples/default_headers.rs
+++ b/examples/default_headers.rs
@@ -3,7 +3,7 @@
 use tide::middleware::DefaultHeaders;
 
 fn main() {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
 
     app.middleware(
         DefaultHeaders::new()

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -47,7 +47,7 @@ type Schema = juniper::RootNode<'static, Query, Mutation>;
 // `Deserialize`, so we use `Json` extractor to deserialize the request body.
 async fn handle_graphql(mut cx: Context<Data>) -> EndpointResult {
     let query: juniper::http::GraphQLRequest = await!(cx.body_json()).client_err()?;
-    let response = query.execute(&Schema::new(Query, Mutation), cx.app_data());
+    let response = query.execute(&Schema::new(Query, Mutation), cx.state());
     let status = if response.is_ok() {
         StatusCode::OK
     } else {

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -59,7 +59,7 @@ async fn handle_graphql(mut cx: Context<Data>) -> EndpointResult {
 }
 
 fn main() {
-    let mut app = App::new(Data::default());
+    let mut app = App::with_state(Data::default());
     app.at("/graphql").post(handle_graphql);
     app.serve("127.0.0.1:8000").unwrap();
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,7 +1,7 @@
 #![feature(async_await)]
 
 fn main() {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
     app.at("/").get(async move |_| "Hello, world!");
     app.serve("127.0.0.1:8000").unwrap();
 }

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -65,7 +65,7 @@ async fn get_message(cx: Context<Database>) -> EndpointResult {
 }
 
 fn main() {
-    let mut app = App::new(Database::default());
+    let mut app = App::with_state(Database::default());
     app.at("/message").post(new_message);
     app.at("/message/:id").get(get_message).post(set_message);
     app.serve("127.0.0.1:8000").unwrap();

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -41,14 +41,14 @@ impl Database {
 
 async fn new_message(mut cx: Context<Database>) -> EndpointResult<String> {
     let msg = await!(cx.body_json()).client_err()?;
-    Ok(cx.app_data().insert(msg).to_string())
+    Ok(cx.state().insert(msg).to_string())
 }
 
 async fn set_message(mut cx: Context<Database>) -> EndpointResult<()> {
     let msg = await!(cx.body_json()).client_err()?;
     let id = cx.param("id").client_err()?;
 
-    if cx.app_data().set(id, msg) {
+    if cx.state().set(id, msg) {
         Ok(())
     } else {
         Err(StatusCode::NOT_FOUND)?
@@ -57,7 +57,7 @@ async fn set_message(mut cx: Context<Database>) -> EndpointResult<()> {
 
 async fn get_message(cx: Context<Database>) -> EndpointResult {
     let id = cx.param("id").client_err()?;
-    if let Some(msg) = cx.app_data().get(id) {
+    if let Some(msg) = cx.state().get(id) {
         Ok(response::json(msg))
     } else {
         Err(StatusCode::NOT_FOUND)?

--- a/examples/multipart-form/main.rs
+++ b/examples/multipart-form/main.rs
@@ -56,7 +56,7 @@ async fn upload_file(mut cx: Context<()>) -> EndpointResult {
 }
 
 fn main() {
-    let mut app = App::new(());
+    let mut app = App::new();
     app.at("/upload_file").post(upload_file);
     app.serve("127.0.0.1:8000").unwrap();
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ use crate::{
 /// ```rust, no_run
 /// #![feature(async_await)]
 ///
-/// let mut app = tide::App::new(());
+/// let mut app = tide::App::new();
 /// app.at("/hello").get(async move |_| "Hello, world!");
 /// app.serve("127.0.0.1:8000");
 ///```
@@ -59,7 +59,7 @@ use crate::{
 ///     Ok(format!("Goodbye, {}.", user))
 /// }
 ///
-/// let mut app = tide::App::new(());
+/// let mut app = tide::App::new();
 ///
 /// app.at("/hello/:user").get(hello);
 /// app.at("/goodbye/:user").get(goodbye);
@@ -158,7 +158,7 @@ impl<State: Send + Sync + 'static> App<State> {
     ///
     /// ```rust,no_run
     /// # #![feature(async_await)]
-    /// # let mut app = tide::App::new(());
+    /// # let mut app = tide::App::new();
     /// app.at("/").get(async move |_| "Hello, world!");
     /// ```
     ///
@@ -182,7 +182,7 @@ impl<State: Send + Sync + 'static> App<State> {
     /// Here are some examples omitting the HTTP verb based endpoint selection:
     ///
     /// ```rust,no_run
-    /// # let mut app = tide::App::new(());
+    /// # let mut app = tide::App::new();
     /// app.at("/");
     /// app.at("/hello");
     /// app.at("add_two/:num");
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn simple_static() {
-        let mut router = App::new(());
+        let mut router = App::new();
         router.at("/").get(async move |_| "/");
         router.at("/foo").get(async move |_| "/foo");
         router.at("/foo/bar").get(async move |_| "/foo/bar");
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn nested_static() {
-        let mut router = App::new(());
+        let mut router = App::new();
         router.at("/a").get(async move |_| "/a");
         router.at("/b").nest(|router| {
             router.at("/").get(async move |_| "/b");
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn multiple_methods() {
-        let mut router = App::new(());
+        let mut router = App::new();
         router.at("/a").nest(|router| {
             router.at("/b").get(async move |_| "/a/b GET");
         });

--- a/src/app.rs
+++ b/src/app.rs
@@ -131,13 +131,20 @@ pub struct App<State> {
     data: State,
 }
 
-impl<State: Send + Sync + 'static> App<State> {
+impl App<()> {
     /// Create an empty `App`, with no initial middleware or configuration.
-    pub fn new(data: State) -> App<State> {
+    pub fn new() -> App<()> {
+        Self::with_state(())
+    }
+}
+
+impl<State: Send + Sync + 'static> App<State> {
+    /// Create an `App`, with initial middleware or configuration.
+    pub fn with_state(state: State) -> App<State> {
         App {
             router: Router::new(),
             middleware: Vec::new(),
-            data,
+            data: state,
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -125,15 +125,15 @@ use crate::{
 ///     app.serve("127.0.0.1:8000").unwrap();
 /// }
 
-pub struct App<AppData> {
-    router: Router<AppData>,
-    middleware: Vec<Arc<dyn Middleware<AppData>>>,
-    data: AppData,
+pub struct App<State> {
+    router: Router<State>,
+    middleware: Vec<Arc<dyn Middleware<State>>>,
+    data: State,
 }
 
-impl<AppData: Send + Sync + 'static> App<AppData> {
+impl<State: Send + Sync + 'static> App<State> {
     /// Create an empty `App`, with no initial middleware or configuration.
-    pub fn new(data: AppData) -> App<AppData> {
+    pub fn new(data: State) -> App<State> {
         App {
             router: Router::new(),
             middleware: Vec::new(),
@@ -185,7 +185,7 @@ impl<AppData: Send + Sync + 'static> App<AppData> {
     /// There is no fallback route matching, i.e. either a resource is a full
     /// match or not, which means that the order of adding resources has no
     /// effect.
-    pub fn at<'a>(&'a mut self, path: &'a str) -> Route<'a, AppData> {
+    pub fn at<'a>(&'a mut self, path: &'a str) -> Route<'a, State> {
         Route::new(&mut self.router, path.to_owned())
     }
 
@@ -199,7 +199,7 @@ impl<AppData: Send + Sync + 'static> App<AppData> {
     ///
     /// Middleware can only be added at the "top level" of an application,
     /// and is processed in the order in which it is applied.
-    pub fn middleware(&mut self, m: impl Middleware<AppData>) -> &mut Self {
+    pub fn middleware(&mut self, m: impl Middleware<State>) -> &mut Self {
         self.middleware.push(Arc::new(m));
         self
     }
@@ -208,7 +208,7 @@ impl<AppData: Send + Sync + 'static> App<AppData> {
     ///
     /// This lower-level method lets you host a Tide application within an HTTP
     /// server of your choice, via the `http_service` interface crate.
-    pub fn into_http_service(self) -> Server<AppData> {
+    pub fn into_http_service(self) -> Server<State> {
         Server {
             router: Arc::new(self.router),
             data: Arc::new(self.data),
@@ -237,13 +237,13 @@ impl<AppData: Send + Sync + 'static> App<AppData> {
 /// This type is useful only in conjunction with the [`HttpService`] trait,
 /// i.e. for hosting a Tide app within some custom HTTP server.
 #[derive(Clone)]
-pub struct Server<AppData> {
-    router: Arc<Router<AppData>>,
-    data: Arc<AppData>,
-    middleware: Arc<Vec<Arc<dyn Middleware<AppData>>>>,
+pub struct Server<State> {
+    router: Arc<Router<State>>,
+    data: Arc<State>,
+    middleware: Arc<Vec<Arc<dyn Middleware<State>>>>,
 }
 
-impl<AppData: Sync + Send + 'static> HttpService for Server<AppData> {
+impl<State: Sync + Send + 'static> HttpService for Server<State> {
     type Connection = ();
     type ConnectionFuture = future::Ready<Result<(), std::io::Error>>;
     type Fut = BoxFuture<'static, Result<http_service::Response, std::io::Error>>;

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,6 +138,12 @@ impl App<()> {
     }
 }
 
+impl Default for App<()> {
+    fn default() -> App<()> {
+        Self::new()
+    }
+}
+
 impl<State: Send + Sync + 'static> App<State> {
     /// Create an `App`, with initial middleware or configuration.
     pub fn with_state(state: State) -> App<State> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,18 +10,18 @@ use std::{str::FromStr, sync::Arc};
 ///
 /// Contexts also provide *extensions*, a type map primarily used for low-level
 /// communication between middleware and endpoints.
-pub struct Context<AppData> {
-    app_data: Arc<AppData>,
+pub struct Context<State> {
+    app_data: Arc<State>,
     request: http_service::Request,
     route_params: Params,
 }
 
-impl<AppData> Context<AppData> {
+impl<State> Context<State> {
     pub(crate) fn new(
-        app_data: Arc<AppData>,
+        app_data: Arc<State>,
         request: http::Request<Body>,
         route_params: Params,
-    ) -> Context<AppData> {
+    ) -> Context<State> {
         Context {
             app_data,
             request,
@@ -55,7 +55,7 @@ impl<AppData> Context<AppData> {
     }
 
     ///  Access app-global data.
-    pub fn app_data(&self) -> &AppData {
+    pub fn app_data(&self) -> &State {
         &self.app_data
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,19 +11,19 @@ use std::{str::FromStr, sync::Arc};
 /// Contexts also provide *extensions*, a type map primarily used for low-level
 /// communication between middleware and endpoints.
 pub struct Context<State> {
-    app_data: Arc<State>,
+    state: Arc<State>,
     request: http_service::Request,
     route_params: Params,
 }
 
 impl<State> Context<State> {
     pub(crate) fn new(
-        app_data: Arc<State>,
+        state: Arc<State>,
         request: http::Request<Body>,
         route_params: Params,
     ) -> Context<State> {
         Context {
-            app_data,
+            state,
             request,
             route_params,
         }
@@ -55,8 +55,8 @@ impl<State> Context<State> {
     }
 
     ///  Access app-global data.
-    pub fn app_data(&self) -> &State {
-        &self.app_data
+    pub fn state(&self) -> &State {
+        &self.state
     }
 
     /// Extract and parse a route parameter by name.

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -9,7 +9,6 @@ const MIDDLEWARE_MISSING_MSG: &str =
     "CookiesMiddleware must be used to populate request and response cookies";
 
 /// A representation of cookies which wraps `CookieJar` from `cookie` crate
-///
 #[derive(Debug)]
 pub(crate) struct CookieData {
     pub(crate) content: Arc<RwLock<CookieJar>>,

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -41,7 +41,7 @@ pub trait CookiesExt {
     fn remove_cookie(&mut self, cookie: Cookie<'static>) -> Result<(), StringError>;
 }
 
-impl<AppData> CookiesExt for Context<AppData> {
+impl<State> CookiesExt for Context<State> {
     fn get_cookie(&mut self, name: &str) -> Result<Option<Cookie<'static>>, StringError> {
         let cookie_data = self
             .extensions()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -26,7 +26,7 @@ use crate::{response::IntoResponse, Context, Response};
 /// }
 ///
 /// fn main() {
-///     let mut app = tide::App::new(());
+///     let mut app = tide::App::new();
 ///     app.at("/hello").get(hello);
 ///     app.serve("127.0.0.1:8000").unwrap()
 /// }
@@ -42,7 +42,7 @@ use crate::{response::IntoResponse, Context, Response};
 /// }
 ///
 /// fn main() {
-///     let mut app = tide::App::new(());
+///     let mut app = tide::App::new();
 ///     app.at("/hello").get(hello);
 ///     app.serve("127.0.0.1:8000").unwrap()
 /// }

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -16,7 +16,7 @@ pub trait ExtractForms {
     fn body_multipart(&mut self) -> BoxTryFuture<Multipart<Cursor<Vec<u8>>>>;
 }
 
-impl<AppData: Send + Sync + 'static> ExtractForms for Context<AppData> {
+impl<State: Send + Sync + 'static> ExtractForms for Context<State> {
     fn body_form<T: serde::de::DeserializeOwned>(&mut self) -> BoxTryFuture<T> {
         let body = self.take_body();
         box_async! {

--- a/src/middleware/cookies.rs
+++ b/src/middleware/cookies.rs
@@ -89,7 +89,7 @@ mod tests {
     }
 
     fn app() -> crate::App<()> {
-        let mut app = crate::App::new(());
+        let mut app = crate::App::new();
         app.middleware(CookiesMiddleware::new());
 
         app.at("/get").get(retrieve_cookie);

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -12,11 +12,7 @@ pub use self::{cookies::CookiesMiddleware, default_headers::DefaultHeaders, logg
 /// Middleware that wraps around remaining middleware chain.
 pub trait Middleware<State>: 'static + Send + Sync {
     /// Asynchronously handle the request, and return a response.
-    fn handle<'a>(
-        &'a self,
-        cx: Context<State>,
-        next: Next<'a, State>,
-    ) -> BoxFuture<'a, Response>;
+    fn handle<'a>(&'a self, cx: Context<State>, next: Next<'a, State>) -> BoxFuture<'a, Response>;
 }
 
 impl<Data, F> Middleware<Data> for F

--- a/src/querystring.rs
+++ b/src/querystring.rs
@@ -40,7 +40,7 @@ mod tests {
     }
 
     fn app() -> crate::App<()> {
-        let mut app = crate::App::new(());
+        let mut app = crate::App::new();
         app.at("/").get(handler);
         app
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -6,18 +6,18 @@ use crate::{router::Router, Endpoint};
 /// [`Route::at`]) to establish a route, the `Route` type can be used to
 /// establish endpoints for various HTTP methods at that path. Also, using
 /// `nest`, it can be used to set up a subrouter.
-pub struct Route<'a, AppData> {
-    router: &'a mut Router<AppData>,
+pub struct Route<'a, State> {
+    router: &'a mut Router<State>,
     path: String,
 }
 
-impl<'a, AppData: 'static> Route<'a, AppData> {
-    pub(crate) fn new(router: &'a mut Router<AppData>, path: String) -> Route<'a, AppData> {
+impl<'a, State: 'static> Route<'a, State> {
+    pub(crate) fn new(router: &'a mut Router<State>, path: String) -> Route<'a, State> {
         Route { router, path }
     }
 
     /// Extend the route with the given `path`.
-    pub fn at<'b>(&'b mut self, path: &str) -> Route<'b, AppData> {
+    pub fn at<'b>(&'b mut self, path: &str) -> Route<'b, State> {
         let mut p = self.path.clone();
 
         if !p.ends_with('/') && !path.starts_with('/') {
@@ -34,67 +34,67 @@ impl<'a, AppData: 'static> Route<'a, AppData> {
         }
     }
 
-    pub fn nest(&mut self, f: impl FnOnce(&mut Route<'a, AppData>)) -> &mut Self {
+    pub fn nest(&mut self, f: impl FnOnce(&mut Route<'a, State>)) -> &mut Self {
         f(self);
         self
     }
 
     /// Add an endpoint for the given HTTP method
-    pub fn method(&mut self, method: http::Method, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn method(&mut self, method: http::Method, ep: impl Endpoint<State>) -> &mut Self {
         self.router.add(&self.path, method, ep);
         self
     }
 
     /// Add an endpoint for `GET` requests
-    pub fn get(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn get(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::GET, ep);
         self
     }
 
     /// Add an endpoint for `HEAD` requests
-    pub fn head(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn head(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::HEAD, ep);
         self
     }
 
     /// Add an endpoint for `PUT` requests
-    pub fn put(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn put(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::PUT, ep);
         self
     }
 
     /// Add an endpoint for `POST` requests
-    pub fn post(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn post(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::POST, ep);
         self
     }
 
     /// Add an endpoint for `DELETE` requests
-    pub fn delete(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn delete(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::DELETE, ep);
         self
     }
 
     /// Add an endpoint for `OPTIONS` requests
-    pub fn options(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn options(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::OPTIONS, ep);
         self
     }
 
     /// Add an endpoint for `CONNECT` requests
-    pub fn connect(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn connect(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::CONNECT, ep);
         self
     }
 
     /// Add an endpoint for `PATCH` requests
-    pub fn patch(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn patch(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::PATCH, ep);
         self
     }
 
     /// Add an endpoint for `TRACE` requests
-    pub fn trace(&mut self, ep: impl Endpoint<AppData>) -> &mut Self {
+    pub fn trace(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::TRACE, ep);
         self
     }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -12,7 +12,7 @@ async fn add_one(cx: Context<()>) -> Result<String, tide::Error> {
 
 #[test]
 fn wildcard() {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
     app.at("/add_one/:num").get(add_one);
     let mut server = make_server(app.into_http_service()).unwrap();
 
@@ -35,7 +35,7 @@ fn wildcard() {
 
 #[test]
 fn invalid_segment_error() {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
     app.at("/add_one/:num").get(add_one);
     let mut server = make_server(app.into_http_service()).unwrap();
 
@@ -48,7 +48,7 @@ fn invalid_segment_error() {
 
 #[test]
 fn not_found_error() {
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
     app.at("/add_one/:num").get(add_one);
     let mut server = make_server(app.into_http_service()).unwrap();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change App constructor
close: https://github.com/rustasync/tide/issues/190
## Description
<!--- Describe your changes in detail -->
- Change type name of App structure to State
- Implement App::with_state constructor
- Change App::new(()) to App::new()
- Fixed the part that is 'App :: new (())'

The changes not related to this PR are also included
- Remove unnecessary line  546a223
- Formatting README ab3b2d7

Open another PR for modification of the generics argument 'AppData' (change to State)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/rustasync/tide/blob/master/rfcs/001-app-new.md 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run ```cargo build``` and ```cargo test```.
There seems to be no problem because the example code works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
