### PR TITLE
Rename `serve` to `run`, add asynchronous `serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Ecosystem WG, and **not ready for production use yet**.
 fn main() -> Result<(), std::io::Error> {
     let mut app = tide::App::new();
     app.at("/").get(async move |_| "Hello, world!");
-    Ok(app.serve("127.0.0.1:8000")?)
+    Ok(app.run("127.0.0.1:8000")?)
 }
 ```
 

--- a/examples/src/body_types.rs
+++ b/examples/src/body_types.rs
@@ -47,5 +47,5 @@ pub fn main() {
     app.at("/echo/json").post(echo_json);
     app.at("/echo/form").post(echo_form);
 
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/src/catch_all.rs
+++ b/examples/src/catch_all.rs
@@ -8,5 +8,5 @@ async fn echo_path(cx: Context<()>) -> String {
 pub fn main() {
     let mut app = tide::App::new();
     app.at("/echo_path/*path").get(echo_path);
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/src/cookies.rs
+++ b/examples/src/cookies.rs
@@ -23,5 +23,5 @@ pub fn main() {
     app.at("/").get(retrieve_cookie);
     app.at("/set").get(set_cookie);
     app.at("/remove").get(remove_cookie);
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/src/default_headers.rs
+++ b/examples/src/default_headers.rs
@@ -11,5 +11,5 @@ pub fn main() {
 
     app.at("/").get(async move |_| "Hello, world!");
 
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/src/graphql.rs
+++ b/examples/src/graphql.rs
@@ -59,5 +59,5 @@ async fn handle_graphql(mut cx: Context<Data>) -> EndpointResult {
 pub fn main() {
     let mut app = App::with_state(Data::default());
     app.at("/graphql").post(handle_graphql);
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/src/hello.rs
+++ b/examples/src/hello.rs
@@ -1,5 +1,5 @@
 pub fn main() {
     let mut app = tide::App::new();
     app.at("/").get(async move |_| "Hello, world!");
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/src/messages.rs
+++ b/examples/src/messages.rs
@@ -68,5 +68,5 @@ pub fn main() {
     let mut app = App::with_state(Database::default());
     app.at("/message").post(new_message);
     app.at("/message/:id").get(get_message).post(set_message);
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/src/multipart_form/mod.rs
+++ b/examples/src/multipart_form/mod.rs
@@ -58,7 +58,7 @@ async fn upload_file(mut cx: Context<()>) -> EndpointResult {
 pub fn run() {
     let mut app = App::new();
     app.at("/upload_file").post(upload_file);
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }
 
 // Test with:

--- a/examples/src/staticfile.rs
+++ b/examples/src/staticfile.rs
@@ -122,5 +122,5 @@ async fn handle_path(ctx: Context<StaticFile>) -> EndpointResult {
 pub fn main() {
     let mut app = App::with_state(StaticFile::new("./"));
     app.at("/*").get(handle_path);
-    app.serve("127.0.0.1:8000").unwrap();
+    app.run("127.0.0.1:8000").unwrap();
 }

--- a/tide/src/app.rs
+++ b/tide/src/app.rs
@@ -256,7 +256,9 @@ impl<State: Send + Sync + 'static> App<State> {
             .ok_or(std::io::ErrorKind::InvalidInput)?;
 
         // TODO: propagate the error from hyper
-        http_service_hyper::serve(self.into_http_service(), addr).await.ok();
+        http_service_hyper::serve(self.into_http_service(), addr)
+            .await
+            .ok();
         Ok(())
     }
 }

--- a/tide/src/endpoint.rs
+++ b/tide/src/endpoint.rs
@@ -28,7 +28,7 @@ use crate::{response::IntoResponse, Context, Response};
 /// fn main() {
 ///     let mut app = tide::App::new();
 ///     app.at("/hello").get(hello);
-///     app.serve("127.0.0.1:8000").unwrap()
+///     app.run("127.0.0.1:8000").unwrap()
 /// }
 /// ```
 ///
@@ -43,7 +43,7 @@ use crate::{response::IntoResponse, Context, Response};
 /// fn main() {
 ///     let mut app = tide::App::new();
 ///     app.at("/hello").get(hello);
-///     app.serve("127.0.0.1:8000").unwrap()
+///     app.run("127.0.0.1:8000").unwrap()
 /// }
 /// ```
 ///


### PR DESCRIPTION
## Description
* Rename original `serve` to `run`.
* Add `App::serve` that returns a `Future`.

## Motivation and Context
This provides flexibility when composing app server with other futures. (cc #163)

## How Has This Been Tested?
No new tests, existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
