### PR TITLE
[WIP] Update futures-preview to 0.3.0-alpha.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2019-04-25
+  - nightly-2019-05-09
 
 before_script: |
   rustup component add rustfmt clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ repository = "https://github.com/rustasync/tide"
 version = "0.2.0"
 
 [dependencies]
-cookie = { version="0.11", features = ["percent-encode"] }
-futures-preview = "0.3.0-alpha.15"
+cookie = { version = "0.11", features = ["percent-encode"] }
+futures-preview = "0.3.0-alpha.16"
 fnv = "1.0.6"
 http = "0.1"
 http-service = "0.2.0"
@@ -54,3 +54,6 @@ juniper = "0.10.0"
 structopt = "0.2.15"
 http-service-mock = "0.2.0"
 serde = { version = "1.0.90", features = ["derive"] }
+
+[patch.crates-io]
+http-service = { git = "https://github.com/taiki-e/http-service", branch = "await" }

--- a/examples/body_types.rs
+++ b/examples/body_types.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use serde::{Deserialize, Serialize};
 use tide::{
@@ -14,25 +14,25 @@ struct Message {
 }
 
 async fn echo_string(mut cx: Context<()>) -> String {
-    let msg = await!(cx.body_string()).unwrap();
+    let msg = cx.body_string().await.unwrap();
     println!("String: {}", msg);
     msg
 }
 
 async fn echo_bytes(mut cx: Context<()>) -> Vec<u8> {
-    let msg = await!(cx.body_bytes()).unwrap();
+    let msg = cx.body_bytes().await.unwrap();
     println!("Bytes: {:?}", msg);
     msg
 }
 
 async fn echo_json(mut cx: Context<()>) -> EndpointResult {
-    let msg = await!(cx.body_json()).client_err()?;
+    let msg = cx.body_json().await.client_err()?;
     println!("JSON: {:?}", msg);
     Ok(response::json(msg))
 }
 
 async fn echo_form(mut cx: Context<()>) -> EndpointResult {
-    let msg = await!(cx.body_form())?;
+    let msg = cx.body_form().await?;
     println!("Form: {:?}", msg);
     Ok(forms::form(msg))
 }

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -3,7 +3,7 @@
 //
 // [the Juniper book]: https://graphql-rust.github.io/
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use http::status::StatusCode;
 use juniper::graphql_object;
@@ -46,7 +46,7 @@ type Schema = juniper::RootNode<'static, Query, Mutation>;
 // Finally, we'll bridge between Tide and Juniper. `GraphQLRequest` from Juniper implements
 // `Deserialize`, so we use `Json` extractor to deserialize the request body.
 async fn handle_graphql(mut cx: Context<Data>) -> EndpointResult {
-    let query: juniper::http::GraphQLRequest = await!(cx.body_json()).client_err()?;
+    let query: juniper::http::GraphQLRequest = cx.body_json().await.client_err()?;
     let response = query.execute(&Schema::new(Query, Mutation), cx.state());
     let status = if response.is_ok() {
         StatusCode::OK

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use http::status::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -40,12 +40,12 @@ impl Database {
 }
 
 async fn new_message(mut cx: Context<Database>) -> EndpointResult<String> {
-    let msg = await!(cx.body_json()).client_err()?;
+    let msg = cx.body_json().await.client_err()?;
     Ok(cx.state().insert(msg).to_string())
 }
 
 async fn set_message(mut cx: Context<Database>) -> EndpointResult<()> {
-    let msg = await!(cx.body_json()).client_err()?;
+    let msg = cx.body_json().await.client_err()?;
     let id = cx.param("id").client_err()?;
 
     if cx.state().set(id, msg) {

--- a/examples/multipart-form/main.rs
+++ b/examples/multipart-form/main.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use serde::{Deserialize, Serialize};
 use std::io::Read;
@@ -19,7 +19,8 @@ async fn upload_file(mut cx: Context<()>) -> EndpointResult {
         file: None,
     };
 
-    await!(cx.body_multipart())?
+    cx.body_multipart()
+        .await?
         .foreach_entry(|mut entry| match entry.headers.name.as_str() {
             "file" => {
                 let mut vec = Vec::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -75,7 +75,7 @@ use crate::{
 /// # Application state
 ///
 /// ```rust, no_run, ignore
-/// #![feature(async_await, futures_api, await_macro)]
+/// #![feature(async_await, futures_api)]
 ///
 /// use tide::{Context, EndpointResult, error::ResultExt, response, App};
 /// use http::StatusCode;
@@ -99,7 +99,7 @@ use crate::{
 /// }
 ///
 /// async fn new_message(cx: Context<Database>) -> EndpointResult<String> {
-///     let msg = await!(cx.body_json()).client_err()?;
+///     let msg = cx.body_json().await.client_err()?;
 ///
 ///     let mut messages = cx.app_data().messages();
 ///     let id = messages.len();
@@ -285,7 +285,7 @@ impl<State: Sync + Send + 'static> HttpService for Server<State> {
                 next.run(cx)
             };
 
-            Ok(await!(fut))
+            Ok(fut.await)
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ use crate::{
 /// segments as parameters to endpoints:
 ///
 /// ```rust, no_run
-/// #![feature(async_await, futures_api)]
+/// #![feature(async_await)]
 ///
 /// use tide::error::ResultExt;
 ///
@@ -75,7 +75,7 @@ use crate::{
 /// # Application state
 ///
 /// ```rust, no_run, ignore
-/// #![feature(async_await, futures_api)]
+/// #![feature(async_await)]
 ///
 /// use tide::{Context, EndpointResult, error::ResultExt, response, App};
 /// use http::StatusCode;

--- a/src/context.rs
+++ b/src/context.rs
@@ -89,7 +89,7 @@ impl<State> Context<State> {
     /// Any I/O error encountered while reading the body is immediately returned
     /// as an `Err`.
     pub async fn body_bytes(&mut self) -> std::io::Result<Vec<u8>> {
-        await!(self.take_body().into_vec())
+        self.take_body().into_vec().await
     }
 
     /// Reads the entire request body into a string.
@@ -104,7 +104,7 @@ impl<State> Context<State> {
     ///
     /// If the body cannot be interpreted as valid UTF-8, an `Err` is returned.
     pub async fn body_string(&mut self) -> std::io::Result<String> {
-        let body_bytes = await!(self.body_bytes())?;
+        let body_bytes = self.body_bytes().await?;
         Ok(String::from_utf8(body_bytes).map_err(|_| std::io::ErrorKind::InvalidData)?)
     }
 
@@ -118,7 +118,7 @@ impl<State> Context<State> {
     /// If the body cannot be interpreted as valid json for the target type `T`,
     /// an `Err` is returned.
     pub async fn body_json<T: serde::de::DeserializeOwned>(&mut self) -> std::io::Result<T> {
-        let body_bytes = await!(self.body_bytes())?;
+        let body_bytes = self.body_bytes().await?;
         Ok(serde_json::from_slice(&body_bytes).map_err(|_| std::io::ErrorKind::InvalidData)?)
     }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -14,13 +14,13 @@ use crate::{response::IntoResponse, Context, Response};
 ///
 /// Endpoints are implemented as asynchronous functions that make use of language features
 /// currently only available in Rust Nightly. For this reason, we have to explicitly enable
-/// those features with `#![feature(async_await, futures_api)]`. To keep examples concise,
+/// those features with `#![feature(async_await)]`. To keep examples concise,
 /// the attribute will be omitted in most of the documentation.
 ///
 /// A simple endpoint that is invoked on a `GET` request and returns a `String`:
 ///
 /// ```rust, no_run
-/// # #![feature(async_await, futures_api)]
+/// # #![feature(async_await)]
 /// async fn hello(_cx: tide::Context<()>) -> String {
 ///     String::from("hello")
 /// }
@@ -35,7 +35,6 @@ use crate::{response::IntoResponse, Context, Response};
 /// An endpoint with similar functionality that does not make use of the `async` keyword would look something like this:
 ///
 /// ```rust, no_run
-/// # #![feature(futures_api)]
 /// # use core::future::Future;
 /// fn hello(_cx: tide::Context<()>) -> impl Future<Output = String> {
 ///     futures::future::ready(String::from("hello"))

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -70,7 +70,7 @@ where
     fn call(&self, cx: Context<State>) -> Self::Fut {
         let fut = (self)(cx);
         box_async! {
-            await!(fut).into_response()
+            fut.await.into_response()
         }
     }
 }

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -20,7 +20,7 @@ impl<State: Send + Sync + 'static> ExtractForms for Context<State> {
     fn body_form<T: serde::de::DeserializeOwned>(&mut self) -> BoxTryFuture<T> {
         let body = self.take_body();
         box_async! {
-            let body = await!(body.into_vec()).client_err()?;
+            let body = body.into_vec().await.client_err()?;
             Ok(serde_urlencoded::from_bytes(&body).map_err(|e| err_fmt!("could not decode form: {}", e)).client_err()?)
         }
     }
@@ -36,7 +36,7 @@ impl<State: Send + Sync + 'static> ExtractForms for Context<State> {
         let body = self.take_body();
 
         box_async! {
-            let body = await!(body.into_vec()).client_err()?;
+            let body = body.into_vec().await.client_err()?;
             let boundary = boundary.ok_or_else(|| err_fmt!("no boundary found")).client_err()?;
             Ok(Multipart::with_body(Cursor::new(body), boundary))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(test, deny(warnings))]
-#![feature(async_await, await_macro, existential_type)]
+#![feature(async_await, existential_type)]
 #![allow(unused_variables)]
 #![deny(nonstandard_style, rust_2018_idioms, future_incompatible)]
 // TODO: Remove this after clippy bug due to async await is resolved.

--- a/src/middleware/cookies.rs
+++ b/src/middleware/cookies.rs
@@ -40,7 +40,7 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for CookiesMiddleware {
             let cookie_jar = cookie_data.content.clone();
 
             cx.extensions_mut().insert(cookie_data);
-            let mut res = await!(next.run(cx));
+            let mut res = next.run(cx).await;
             let headers = res.headers_mut();
             for cookie in cookie_jar.read().unwrap().delta() {
                 let hv = HeaderValue::from_str(cookie.encoded().to_string().as_str());

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -42,7 +42,7 @@ impl DefaultHeaders {
 impl<Data: Send + Sync + 'static> Middleware<Data> for DefaultHeaders {
     fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> BoxFuture<'a, Response> {
         box_async! {
-            let mut res = await!(next.run(cx));
+            let mut res = next.run(cx).await;
 
             let headers = res.headers_mut();
             for (key, value) in self.headers.iter() {

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -40,7 +40,7 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for RootLogger {
             let path = cx.uri().path().to_owned();
             let method = cx.method().as_str().to_owned();
 
-            let res = await!(next.run(cx));
+            let res = next.run(cx).await;
             let status = res.status();
             info!(self.inner_logger, "{} {} {}", method, path, status.as_str());
             res


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`await` syntax was implemented in https://github.com/rust-lang/rust/pull/60586, and nightly-2019-05-09 has been released with the changes. Also, `await!` macro will be removed in the future.

Then, futures 0.3.0-alpha.16 was released.

Refs: [migration tool](https://github.com/taiki-e/replace-await)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

With this change, the minimum required version will go up to nightly-2019-05-09.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
