### PR TITLE
Delete rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-edition = "2018"
-tab_spaces = 4


### PR DESCRIPTION
Both options used are defaults, and it is encouraged not to configure rustfmt if possible.