### PR TITLE
Add error::ResultDynErrExt

### DIFF
--- a/tide-core/src/error.rs
+++ b/tide-core/src/error.rs
@@ -1,5 +1,3 @@
-// use core::pin::Pin;
-// use futures::future::Future;
 use http::{HttpTryFrom, Response, StatusCode};
 use http_service::Body;
 
@@ -55,6 +53,18 @@ impl From<StatusCode> for Error {
     }
 }
 
+/// Extends the `Response` type with a method to extract error causes when applicable.
+pub trait ResponseExt {
+    /// Extract the cause of the unsuccessful response, if any
+    fn err_cause(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)>;
+}
+
+impl<T> ResponseExt for Response<T> {
+    fn err_cause(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
+        self.extensions().get().map(|Cause(c)| &**c)
+    }
+}
+
 /// Extends the `Result` type with convenient methods for constructing Tide errors.
 pub trait ResultExt<T>: Sized {
     /// Convert to an `EndpointResult`, treating the `Err` case as a client
@@ -76,19 +86,39 @@ pub trait ResultExt<T>: Sized {
         StatusCode: HttpTryFrom<S>;
 }
 
-/// Extends the `Response` type with a method to extract error causes when applicable.
-pub trait ResponseExt {
-    /// Extract the cause of the unsuccessful response, if any
-    fn err_cause(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)>;
-}
-
-impl<T> ResponseExt for Response<T> {
-    fn err_cause(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
-        self.extensions().get().map(|Cause(c)| &**c)
+impl<T, E: std::error::Error + Send + Sync + 'static> ResultExt<T> for std::result::Result<T, E> {
+    fn with_err_status<S>(self, status: S) -> EndpointResult<T>
+    where
+        StatusCode: HttpTryFrom<S>,
+    {
+        let r = self.map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>);
+        r.with_err_status(status)
     }
 }
 
-impl<T, E: std::error::Error + Send + Sync + 'static> ResultExt<T> for std::result::Result<T, E> {
+/// Extends the `Result` type using `std::error::Error` trait object as the error type with
+/// convenient methods for constructing Tide errors.
+pub trait ResultDynErrExt<T>: Sized {
+    /// Convert to an `EndpointResult`, treating the `Err` case as a client
+    /// error (response code 400).
+    fn client_err(self) -> EndpointResult<T> {
+        self.with_err_status(400)
+    }
+
+    /// Convert to an `EndpointResult`, treating the `Err` case as a server
+    /// error (response code 500).
+    fn server_err(self) -> EndpointResult<T> {
+        self.with_err_status(500)
+    }
+
+    /// Convert to an `EndpointResult`, wrapping the `Err` case with a custom
+    /// response status.
+    fn with_err_status<S>(self, status: S) -> EndpointResult<T>
+    where
+        StatusCode: HttpTryFrom<S>;
+}
+
+impl<T> ResultDynErrExt<T> for std::result::Result<T, Box<dyn std::error::Error + Send + Sync>> {
     fn with_err_status<S>(self, status: S) -> EndpointResult<T>
     where
         StatusCode: HttpTryFrom<S>,
@@ -96,7 +126,7 @@ impl<T, E: std::error::Error + Send + Sync + 'static> ResultExt<T> for std::resu
         self.map_err(|e| Error {
             resp: Response::builder()
                 .status(status)
-                .extension(Cause(Box::new(e)))
+                .extension(Cause(e))
                 .body(Body::empty())
                 .unwrap(),
         })


### PR DESCRIPTION
Add `error::ResultDynErrExt`, which provide the same set of methods in `error::ResultErr` for `Result<T, Box<dyn Error>>`.

## Motivation and Context
Trying to resolve issue #208. With this PR, a `e: Result<T, Box<dyn Error>>` can call `e.client_err()`, `e.server_err()` conveniently.

This introduces duplicate codes with `error::ResultErr`. But I did not figure out a way to avoid that.

## How Has This Been Tested?
Not tested - mostly just copy and paste `error::ResultErr`, which does not have a test case for now.
I have no problem adding a unit test if necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
