### PR TITLE
Rename extension traits for Cookies and QueryString

### DIFF
--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,7 +1,7 @@
 #![feature(async_await)]
 
 use cookie::Cookie;
-use tide::{cookies::CookiesExt, middleware::CookiesMiddleware, Context};
+use tide::{cookies::ContextExt, middleware::CookiesMiddleware, Context};
 
 /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
 ///

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -28,7 +28,7 @@ impl CookieData {
 }
 
 /// An extension to `Context` that provides cached access to cookies
-pub trait CookiesExt {
+pub trait ContextExt {
     /// returns a `Cookie` by name of the cookie
     fn get_cookie(&mut self, name: &str) -> Result<Option<Cookie<'static>>, StringError>;
 
@@ -40,7 +40,7 @@ pub trait CookiesExt {
     fn remove_cookie(&mut self, cookie: Cookie<'static>) -> Result<(), StringError>;
 }
 
-impl<State> CookiesExt for Context<State> {
+impl<State> ContextExt for Context<State> {
     fn get_cookie(&mut self, name: &str) -> Result<Option<Cookie<'static>>, StringError> {
         let cookie_data = self
             .extensions()

--- a/src/middleware/cookies.rs
+++ b/src/middleware/cookies.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// Middleware to work with cookies.
 ///
-/// [`CookiesMiddleware`] along with [`CookiesExt`](crate::cookies::CookiesExt) provide smooth
+/// [`CookiesMiddleware`] along with [`ContextExt`](crate::cookies::ContextExt) provide smooth
 /// access to request cookies and setting/removing cookies from response. This leverages the
 /// [cookie](https://crates.io/crates/cookie) crate.
 /// This middleware parses cookies from request and caches them in the extension. Once the request
@@ -63,7 +63,7 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for CookiesMiddleware {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{cookies::CookiesExt, Context};
+    use crate::{cookies::ContextExt, Context};
     use cookie::Cookie;
     use futures::executor::block_on;
     use http_service::Body;

--- a/src/querystring.rs
+++ b/src/querystring.rs
@@ -3,11 +3,11 @@ use http::StatusCode;
 use serde::Deserialize;
 
 /// An extension trait for `Context`, providing query string deserialization.
-pub trait ExtractQuery<'de> {
+pub trait ContextExt<'de> {
     fn url_query<T: Deserialize<'de>>(&'de self) -> Result<T, Error>;
 }
 
-impl<'de, Data> ExtractQuery<'de> for Context<Data> {
+impl<'de, Data> ContextExt<'de> for Context<Data> {
     #[inline]
     fn url_query<T: Deserialize<'de>>(&'de self) -> Result<T, Error> {
         let query = self.uri().query();


### PR DESCRIPTION
As discussed in #187, functionality of extension traits be identifiable by import path, and the trait itself should be named after the type it extends.

To satisfy those constraints, `querystring::ExtractQuery` becomes `querystring::ContextExt`. Similarly, `cookies::CookiesExt` is now `cookies::ContextExt`. 

Ideally, these changes will land before #162.

## Motivation and Context

To align with Rust best practices and the direction of current project discussions.

## How Has This Been Tested?

Current tests pass after being modified to import new types.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
