### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,30 @@
 language: rust
-rust:
-  - nightly-2019-05-09
-
-before_script: |
-  rustup component add rustfmt clippy
-script: |
-  cargo fmt --all -- --check &&
-  cargo clippy --all --all-features -- -D clippy::all &&
-  cargo build --no-default-features --verbose &&
-  cargo build --all --all-features --verbose &&
-  cargo test --all --all-features --verbose
+rust: nightly-2019-05-09
 cache: cargo
+
+matrix:
+  include:
+  - name: cargo doc
+    env: [CACHE_NAME=docs]
+    script:
+    - RUSTDOCFLAGS=-Dwarnings
+      cargo doc --all --all-features --no-deps --exclude tide
+
+  - name: cargo fmt
+    cache: false
+    before_script: rustup component add rustfmt
+    script: cargo fmt --all -- --check
+
+  - name: cargo clippy
+    env: [CACHE_NAME=clippy]
+    before_script: rustup component add clippy
+    script: cargo clippy --all --all-targets --exclude examples -- -Dwarnings
+
+  - name: cargo build --no-default-features
+    env: [CACHE_NAME=no-default-features]
+    script:
+    - cargo build --manifest-path tide/Cargo.toml --no-default-features
+    - cargo build --manifest-path tide-core/Cargo.toml --no-default-features
+
+  - name: cargo test
+    script: cargo test --all --verbose

--- a/tide-compression/src/lib.rs
+++ b/tide-compression/src/lib.rs
@@ -289,8 +289,7 @@ mod tests {
             .header(ACCEPT_ENCODING, hval)
             .body(Body::empty())
             .unwrap();
-        let res = server.simulate(req).unwrap();
-        res
+        server.simulate(req).unwrap()
     }
 
     // Generates a decoded response given a request body and the header value representing its encoding.
@@ -301,8 +300,7 @@ mod tests {
             .header(CONTENT_ENCODING, hval)
             .body(body)
             .unwrap();
-        let res = server.simulate(req).unwrap();
-        res
+        server.simulate(req).unwrap()
     }
 
     #[test]

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -9,7 +9,7 @@ use tide_core::{
 
 /// Middleware to work with cookies.
 ///
-/// [`CookiesMiddleware`] along with [`ContextExt`](crate::cookies::ContextExt) provide smooth
+/// [`CookiesMiddleware`] along with [`ContextExt`](crate::data::ContextExt) provide smooth
 /// access to request cookies and setting/removing cookies from response. This leverages the
 /// [cookie](https://crates.io/crates/cookie) crate.
 /// This middleware parses cookies from request and caches them in the extension. Once the request

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -74,7 +74,11 @@ mod tests {
 
     /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
     async fn retrieve_cookie(mut cx: Context<()>) -> String {
-        format!("{}", cx.get_cookie(COOKIE_NAME).unwrap().unwrap().value())
+        cx.get_cookie(COOKIE_NAME)
+            .unwrap()
+            .unwrap()
+            .value()
+            .to_string()
     }
 
     async fn set_cookie(mut cx: Context<()>) {
@@ -109,8 +113,7 @@ mod tests {
             .header(http::header::COOKIE, "testCookie=RequestCookieValue")
             .body(Body::empty())
             .unwrap();
-        let res = server.simulate(req).unwrap();
-        res
+        server.simulate(req).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 * Separate out individual build jobs for faster wall-clock testing

 * Fix clippy not actually denying warnings (excluded examples because these are currently failing and have non-trivial fixes, https://github.com/rustasync/tide/issues/230)

 * Add build job that checks --no-default-features works

 * Add build job that checks for intra-doc-resolution failures (excluded tide because of bugs in re-exports with the intra-doc feature, https://github.com/rust-lang/rust/issues/60883)

(based on top of #220, [relevant changes](https://github.com/rustasync/tide/compare/wafflespeanut:code-split..Nemo157:update-travis))
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #226, improves feedback speed on PRs, keeps code quality high
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
In Travis
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.