### PR TITLE
remove async box macro

### DIFF
--- a/tide-compression/src/lib.rs
+++ b/tide-compression/src/lib.rs
@@ -13,6 +13,7 @@
 pub use accept_encoding::Encoding;
 use async_compression::stream;
 use futures::future::BoxFuture;
+use futures::prelude::*;
 use http::{header::CONTENT_ENCODING, status::StatusCode, HeaderMap};
 use http_service::{Body, Request};
 use tide::{
@@ -20,12 +21,6 @@ use tide::{
     response::IntoResponse,
     Context, Error, Response,
 };
-
-macro_rules! box_async {
-    {$($t:tt)*} => {
-        ::futures::future::FutureExt::boxed(async move { $($t)* })
-    };
-}
 
 /// Encode settings for the compression middleware.
 ///
@@ -137,14 +132,14 @@ impl Compression {
 
 impl<Data: Send + Sync + 'static> Middleware<Data> for Compression {
     fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> BoxFuture<'a, Response> {
-        box_async! {
+        FutureExt::boxed(async move {
             let encoding = match self.preferred_encoding(cx.headers()) {
                 Ok(encoding) => encoding,
                 Err(e) => return e.into_response(),
             };
             let res = next.run(cx).await;
             self.encode(res, encoding)
-        }
+        })
     }
 }
 
@@ -225,13 +220,13 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for Decompression {
         mut cx: Context<Data>,
         next: Next<'a, Data>,
     ) -> BoxFuture<'a, Response> {
-        box_async! {
+        FutureExt::boxed(async move {
             match self.decode(cx.request_mut()) {
                 Ok(_) => (),
                 Err(e) => return e.into_response(),
             };
             next.run(cx).await
-        }
+        })
     }
 }
 

--- a/tide-cookies/src/lib.rs
+++ b/tide-cookies/src/lib.rs
@@ -8,9 +8,6 @@
     missing_debug_implementations
 )]
 
-#[macro_use]
-extern crate tide_core;
-
 mod data;
 mod middleware;
 

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -1,6 +1,7 @@
 use crate::data::CookieData;
 use futures::future::BoxFuture;
 use http::header::HeaderValue;
+use futures::prelude::*;
 
 use tide_core::{
     middleware::{Middleware, Next},
@@ -31,7 +32,7 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for CookiesMiddleware {
         mut cx: Context<Data>,
         next: Next<'a, Data>,
     ) -> BoxFuture<'a, Response> {
-        box_async! {
+        FutureExt::boxed(async move {
             let cookie_data = cx
                 .extensions_mut()
                 .remove()
@@ -56,7 +57,7 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for CookiesMiddleware {
                 }
             }
             res
-        }
+        })
     }
 }
 

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -1,7 +1,7 @@
 use crate::data::CookieData;
 use futures::future::BoxFuture;
-use http::header::HeaderValue;
 use futures::prelude::*;
+use http::header::HeaderValue;
 
 use tide_core::{
     middleware::{Middleware, Next},

--- a/tide-core/src/app.rs
+++ b/tide-core/src/app.rs
@@ -1,4 +1,5 @@
 use futures::future::{self, BoxFuture};
+use futures::prelude::*;
 use http_service::HttpService;
 use std::sync::Arc;
 
@@ -292,7 +293,7 @@ impl<State: Sync + Send + 'static> HttpService for Server<State> {
         let middleware = self.middleware.clone();
         let data = self.data.clone();
 
-        box_async! {
+        FutureExt::boxed(async move {
             let fut = {
                 let Selection { endpoint, params } = router.route(&path, method);
                 let cx = Context::new(data, req, params);
@@ -306,7 +307,7 @@ impl<State: Sync + Send + 'static> HttpService for Server<State> {
             };
 
             Ok(fut.await)
-        }
+        })
     }
 }
 

--- a/tide-core/src/endpoint.rs
+++ b/tide-core/src/endpoint.rs
@@ -69,8 +69,6 @@ where
     type Fut = BoxFuture<'static, Response>;
     fn call(&self, cx: Context<State>) -> Self::Fut {
         let fut = (self)(cx);
-        FutureExt::boxed(async move {
-            fut.await.into_response()
-        })
+        FutureExt::boxed(async move { fut.await.into_response() })
     }
 }

--- a/tide-core/src/endpoint.rs
+++ b/tide-core/src/endpoint.rs
@@ -1,4 +1,5 @@
 use futures::future::{BoxFuture, Future};
+use futures::prelude::*;
 
 use crate::{response::IntoResponse, Context, Response};
 
@@ -68,8 +69,8 @@ where
     type Fut = BoxFuture<'static, Response>;
     fn call(&self, cx: Context<State>) -> Self::Fut {
         let fut = (self)(cx);
-        box_async! {
+        FutureExt::boxed(async move {
             fut.await.into_response()
-        }
+        })
     }
 }

--- a/tide-core/src/lib.rs
+++ b/tide-core/src/lib.rs
@@ -11,13 +11,6 @@
 // ISSUE: https://github.com/rust-lang/rust-clippy/issues/3988
 #![allow(clippy::needless_lifetimes)]
 
-#[macro_export]
-macro_rules! box_async {
-    {$($t:tt)*} => {
-        ::futures::future::FutureExt::boxed(async move { $($t)* })
-    };
-}
-
 mod app;
 mod context;
 mod endpoint;

--- a/tide-core/src/router.rs
+++ b/tide-core/src/router.rs
@@ -1,5 +1,6 @@
 use fnv::FnvHashMap;
-use futures::future::{BoxFuture, FutureExt};
+use futures::future::BoxFuture;
+use futures::prelude::*;
 use http_service::Body;
 use route_recognizer::{Match, Params, Router as MethodRouter};
 
@@ -62,7 +63,7 @@ impl<State: 'static> Router<State> {
 }
 
 fn not_found_endpoint<Data>(_cx: Context<Data>) -> BoxFuture<'static, Response> {
-    box_async! {
+    FutureExt::boxed(async move {
         http::Response::builder().status(http::StatusCode::NOT_FOUND).body(Body::empty()).unwrap()
-    }
+    })
 }

--- a/tide-core/src/router.rs
+++ b/tide-core/src/router.rs
@@ -64,6 +64,9 @@ impl<State: 'static> Router<State> {
 
 fn not_found_endpoint<Data>(_cx: Context<Data>) -> BoxFuture<'static, Response> {
     FutureExt::boxed(async move {
-        http::Response::builder().status(http::StatusCode::NOT_FOUND).body(Body::empty()).unwrap()
+        http::Response::builder()
+            .status(http::StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .unwrap()
     })
 }

--- a/tide/src/forms.rs
+++ b/tide/src/forms.rs
@@ -1,6 +1,6 @@
+use futures::prelude::*;
 use http_service::Body;
 use multipart::server::Multipart;
-use futures::prelude::*;
 use std::io::Cursor;
 
 use crate::{
@@ -22,7 +22,9 @@ impl<State: Send + Sync + 'static> ExtractForms for Context<State> {
         let body = self.take_body();
         FutureExt::boxed(async move {
             let body = body.into_vec().await.client_err()?;
-            Ok(serde_urlencoded::from_bytes(&body).map_err(|e| err_fmt!("could not decode form: {}", e)).client_err()?)
+            Ok(serde_urlencoded::from_bytes(&body)
+                .map_err(|e| err_fmt!("could not decode form: {}", e))
+                .client_err()?)
         })
     }
 
@@ -38,7 +40,9 @@ impl<State: Send + Sync + 'static> ExtractForms for Context<State> {
 
         FutureExt::boxed(async move {
             let body = body.into_vec().await.client_err()?;
-            let boundary = boundary.ok_or_else(|| err_fmt!("no boundary found")).client_err()?;
+            let boundary = boundary
+                .ok_or_else(|| err_fmt!("no boundary found"))
+                .client_err()?;
             Ok(Multipart::with_body(Cursor::new(body), boundary))
         })
     }

--- a/tide/src/lib.rs
+++ b/tide/src/lib.rs
@@ -22,12 +22,6 @@
 #[doc(include = "../../README.md")]
 const _README: () = ();
 
-macro_rules! box_async {
-    {$($t:tt)*} => {
-        ::futures::future::FutureExt::boxed(async move { $($t)* })
-    };
-}
-
 #[macro_use]
 extern crate tide_core;
 

--- a/tide/src/middleware/default_headers.rs
+++ b/tide/src/middleware/default_headers.rs
@@ -1,4 +1,5 @@
 use futures::future::BoxFuture;
+use futures::prelude::*;
 
 use http::{
     header::{HeaderValue, IntoHeaderName},
@@ -41,7 +42,7 @@ impl DefaultHeaders {
 
 impl<Data: Send + Sync + 'static> Middleware<Data> for DefaultHeaders {
     fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> BoxFuture<'a, Response> {
-        box_async! {
+        FutureExt::boxed(async move {
             let mut res = next.run(cx).await;
 
             let headers = res.headers_mut();
@@ -49,6 +50,6 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for DefaultHeaders {
                 headers.entry(key).unwrap().or_insert_with(|| value.clone());
             }
             res
-        }
+        })
     }
 }

--- a/tide/src/middleware/logger.rs
+++ b/tide/src/middleware/logger.rs
@@ -3,6 +3,7 @@ use slog_async;
 use slog_term;
 
 use futures::future::BoxFuture;
+use futures::prelude::*;
 
 use crate::{
     middleware::{Middleware, Next},
@@ -37,7 +38,7 @@ impl Default for RootLogger {
 /// is generated.
 impl<Data: Send + Sync + 'static> Middleware<Data> for RootLogger {
     fn handle<'a>(&'a self, cx: Context<Data>, next: Next<'a, Data>) -> BoxFuture<'a, Response> {
-        box_async! {
+        FutureExt::boxed(async move {
             let path = cx.uri().path().to_owned();
             let method = cx.method().as_str().to_owned();
 
@@ -45,6 +46,6 @@ impl<Data: Send + Sync + 'static> Middleware<Data> for RootLogger {
             let status = res.status();
             info!(self.inner_logger, "{} {} {}", method, path, status.as_str());
             res
-        }
+        })
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the `box_async` macro.

## Motivation and Context
Removes the box async macro, removing indirection from the code.

## How Has This Been Tested?
Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
