### PR TITLE
Sweep the cache before uploading it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,57 @@ language: rust
 rust: nightly-2019-05-09
 cache: cargo
 
+before_script:
+- >
+  [[ "$(cargo-sweep --version)" == "cargo-sweep 0.4.1" ]]
+  || cargo install cargo-sweep
+- cargo sweep --stamp
+
+before_cache:
+- cargo sweep --file
+
 matrix:
   include:
   - name: cargo doc
     env: [CACHE_NAME=docs]
     script:
-    - RUSTDOCFLAGS=-Dwarnings
-      cargo doc --all --all-features --no-deps --exclude tide
+    - RUSTDOCFLAGS=-Dwarnings cargo doc
+        -Zmtime-on-use
+        --all --all-features
+        --exclude tide
+        --no-deps
 
   - name: cargo fmt
     cache: false
-    before_script: rustup component add rustfmt
-    script: cargo fmt --all -- --check
+    before_script: []
+    install:
+    - rustup component add rustfmt
+    script:
+    - cargo fmt --all -- --check
 
   - name: cargo clippy
     env: [CACHE_NAME=clippy]
-    before_script: rustup component add clippy
-    script: cargo clippy --all --all-targets --exclude examples -- -Dwarnings
+    install:
+    - rustup component add clippy
+    script:
+    - cargo clippy
+        -Zmtime-on-use
+        --all --all-targets
+        --exclude examples
+        -- -Dwarnings
 
   - name: cargo build --no-default-features
     env: [CACHE_NAME=no-default-features]
     script:
-    - cargo build --manifest-path tide/Cargo.toml --no-default-features
-    - cargo build --manifest-path tide-core/Cargo.toml --no-default-features
+    - cargo build
+        -Zmtime-on-use
+        --manifest-path tide-core/Cargo.toml
+        --no-default-features
+    - cargo build
+        -Zmtime-on-use
+        --manifest-path tide/Cargo.toml
+        --no-default-features
 
   - name: cargo test
-    script: cargo test --all --verbose
+    script:
+    - cargo test -Zmtime-on-use --all --verbose


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use [`cargo-sweep`](https://github.com/holmgr/cargo-sweep) along with [`-Zmtime-on-use`](https://github.com/rust-lang/cargo/pull/6573) for removing unused data from the Travis cache.

`cargo-sweep` will remove all files that were not used during the current build, so for example old versions of dependencies. To be able to track this accurately it needs `cargo`/`rustc` to mark the files it uses during the current build, the `-Zmtime-on-use` flag is an unstable flag to tell it to do so.

With this implemented the files uploaded to Travis should only be the relevant ones, keeping the cache minimal and actually usable. This will then mean that future builds will only have to build what has changed and run much faster.

## Motivation and Context
Fixes #243
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.