### PR TITLE
pub use ResultDynErrExt in tide::error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 use core::pin::Pin;
 use futures::future::Future;
 
-pub use tide_core::error::{EndpointResult, Error, ResponseExt, ResultExt, StringError};
+pub use tide_core::error::{
+    EndpointResult, Error, ResponseExt, ResultDynErrExt, ResultExt, StringError,
+};
 
 pub(crate) type BoxTryFuture<T> = Pin<Box<dyn Future<Output = EndpointResult<T>> + Send + 'static>>;

--- a/tide-core/src/error.rs
+++ b/tide-core/src/error.rs
@@ -79,8 +79,7 @@ pub trait ResultExt<T>: Sized {
         self.with_err_status(500)
     }
 
-    /// Convert to an `EndpointResult`, wrapping the `Err` case with a custom
-    /// response status.
+    /// Convert to an `EndpointResult`, wrapping the `Err` case with a custom response status.
     fn with_err_status<S>(self, status: S) -> EndpointResult<T>
     where
         StatusCode: HttpTryFrom<S>;
@@ -111,8 +110,7 @@ pub trait ResultDynErrExt<T>: Sized {
         self.with_err_status(500)
     }
 
-    /// Convert to an `EndpointResult`, wrapping the `Err` case with a custom
-    /// response status.
+    /// Convert to an `EndpointResult`, wrapping the `Err` case with a custom response status.
     fn with_err_status<S>(self, status: S) -> EndpointResult<T>
     where
         StatusCode: HttpTryFrom<S>;


### PR DESCRIPTION
A trivial follow-up of PR #216.
Issue: #208
