### PR TITLE
Workaround for issue #278: works around Rust internal compiler error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly-2019-05-09
+rust: nightly-2019-06-02
 cache: cargo
 
 before_script:

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -44,7 +44,6 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
 
             let cookie_jar = cookie_data.content.clone();
 
-
             // The `let _ = ...` is a workaround for issue: https://github.com/rustasync/tide/issues/278
             // Solution is according to suggestion in https://github.com/rust-lang/rust/issues/61579#issuecomment-500436524
             let _ = cx.extensions_mut().insert(cookie_data);

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -44,7 +44,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
 
             let cookie_jar = cookie_data.content.clone();
 
-            cx.extensions_mut().insert(cookie_data);
+            let _ = cx.extensions_mut().insert(cookie_data);
             let mut res = next.run(cx).await;
             let headers = res.headers_mut();
             for cookie in cookie_jar.read().unwrap().delta() {

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -44,6 +44,9 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
 
             let cookie_jar = cookie_data.content.clone();
 
+
+            // The `let _ = ...` is a workaround for issue: https://github.com/rustasync/tide/issues/278
+            // Solution is according to suggestion in https://github.com/rust-lang/rust/issues/61579#issuecomment-500436524
             let _ = cx.extensions_mut().insert(cookie_data);
             let mut res = next.run(cx).await;
             let headers = res.headers_mut();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Solves problem mentioned in issue #278. 
Solution according to: https://github.com/rust-lang/rust/issues/61579#issuecomment-500436524

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`tide` can not be compiled after nightly 2019-06-01. However, another rustc bug doesn't allow me to compile my project's code for rustc of version lower than 2019-06-15. Therefore I currently have no possible way of compiling my project.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`cargo test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
