### PR TITLE
Set StatusCode for an empty response from `()` to `204`

### DIFF
--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn successfully_set_cookie() {
         let res = make_request("/set");
-        assert_eq!(res.status(), 200);
+        assert_eq!(res.status(), 204);
         let test_cookie_header = res.headers().get(http::header::SET_COOKIE).unwrap();
         assert_eq!(
             test_cookie_header.to_str().unwrap(),
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn successfully_remove_cookie() {
         let res = make_request("/remove");
-        assert_eq!(res.status(), 200);
+        assert_eq!(res.status(), 204);
         let test_cookie_header = res.headers().get(http::header::SET_COOKIE).unwrap();
         assert!(test_cookie_header
             .to_str()
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn successfully_set_multiple_cookies() {
         let res = make_request("/multi");
-        assert_eq!(res.status(), 200);
+        assert_eq!(res.status(), 204);
         let cookie_header = res.headers().get_all(http::header::SET_COOKIE);
         let mut iter = cookie_header.iter();
 

--- a/tide-core/src/response.rs
+++ b/tide-core/src/response.rs
@@ -38,7 +38,7 @@ pub trait IntoResponse: Send + Sized {
 impl IntoResponse for () {
     fn into_response(self) -> Response {
         http::Response::builder()
-            .status(http::status::StatusCode::OK)
+            .status(http::status::StatusCode::NO_CONTENT)
             .body(Body::empty())
             .unwrap()
     }


### PR DESCRIPTION
Change `()` to return a `204` status code to the client instead of `200`.

## Description

```rust
async fn empty(_: tide::Context) -> tide::EndpointResult<()> {
  Ok(()))
}
```

Currently the above makes a route that will return `200` with an empty response. 

## Motivation and Context

This is problematic as many libraries expect a `200` to return _something_ in the body and the HTTP RFC strongly recommends to use 204 to indicate "no payload". 

http://svn.tools.ietf.org/svn/wg/httpbis/specs/rfc7231.html#status.200

> Aside from responses to CONNECT, a 200 response always has a payload, though an origin server MAY generate a payload body of zero length. If no payload is desired, an origin server ought to send 204 (No Content) instead. For CONNECT, no payload is allowed because the successful result is a tunnel, which begins immediately after the 200 response header section.

See:
 - https://stackoverflow.com/questions/19353083/why-jquery-consider-an-200-response-ajax-request-with-empty-content-as-fail
 - https://github.com/square/retrofit/issues/1105

## How Has This Been Tested?

No. But it's trivial enough. I could add a test if desired.

## Types of changes

- [x] Breaking change

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
