### PR TITLE
Rewrite tide-slog to setup a per-request logger instance and support slog-scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,8 @@ matrix:
   - name: cargo test
     script:
     - cargo test -Zmtime-on-use --all --verbose
+
+  - name: cargo test --all-features
+    script:
+    - cargo test -Zmtime-on-use --all-features
+    - cargo test -Zmtime-on-use --manifest-path tide-slog/Cargo.toml --all-features

--- a/tide-slog/Cargo.toml
+++ b/tide-slog/Cargo.toml
@@ -1,7 +1,5 @@
 [package]
-authors = [
-    "Tide Developers"
-]
+authors = ["Tide Developers"]
 description = "Logging middleware for Tide based on slog"
 documentation = "https://docs.rs/tide-slog"
 keywords = ["tide", "web", "middleware", "logging", "slog"]
@@ -17,14 +15,23 @@ readme = "README.md"
 repository = "https://github.com/rustasync/tide"
 version = "0.1.0"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg docrs"]
+
+[features]
+scope = ["slog-scope", "slog-scope-futures"]
+
 [dependencies]
 tide-core = { path = "../tide-core", default-features = false  }
 futures-preview = "0.3.0-alpha.17"
 http = "0.1"
-log = "0.4.6"
 slog = "2.4.1"
-slog-async = "2.3.0"
-slog-term = "2.4.0"
+slog-scope = { version = "4.1.1", optional = true }
+slog-scope-futures = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 tide = { path = "../", default-features = false }
+uuid = { version = "0.7.4", default-features = false, features = ["v4"] }
+slog-stdlog = "3.0.2"
+slog-scope = "4.1.1"

--- a/tide-slog/src/per_request_logger.rs
+++ b/tide-slog/src/per_request_logger.rs
@@ -1,0 +1,89 @@
+use futures::future::BoxFuture;
+use tide_core::{
+    middleware::{Middleware, Next},
+    Context, Response,
+};
+
+/// Middleware that injects a per-request [`slog::Logger`] onto the request [`Context`].
+pub struct PerRequestLogger<State> {
+    setup: Box<dyn (Fn(&mut Context<State>) -> slog::Logger) + Send + Sync + 'static>,
+}
+
+impl<State> PerRequestLogger<State> {
+    /// Initialize this middleware with a function to create a per-request logger.
+    ///
+    /// # Examples
+    ///
+    /// ## Adding a base16 encoded per-request UUID onto the logger context
+    ///
+    /// ```
+    /// use slog::o;
+    ///
+    /// let mut app = tide::App::new();
+    ///
+    /// let request_id = || uuid::Uuid::new_v4().to_simple().to_string();
+    ///
+    /// let root_logger = slog::Logger::root(slog::Discard, o!());
+    /// app.middleware(tide_slog::PerRequestLogger::with_setup(move |_cx| root_logger.new(o! {
+    ///     "request" => request_id(),
+    /// })));
+    /// ```
+    ///
+    /// ## Taking an externally provided request id from headers for the logger context
+    ///
+    /// ```
+    /// use slog::o;
+    ///
+    /// let mut app = tide::App::new();
+    ///
+    /// let root_logger = slog::Logger::root(slog::Discard, o!());
+    /// app.middleware(tide_slog::PerRequestLogger::with_setup(move |cx| root_logger.new(o! {
+    ///     "request" => cx.headers().get("Request-Id").unwrap().to_str().unwrap().to_owned(),
+    /// })));
+    /// ```
+    pub fn with_setup(
+        setup: impl (Fn(&mut Context<State>) -> slog::Logger) + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            setup: Box::new(setup),
+        }
+    }
+
+    /// Initialize this middleware with a logger that will provided to each request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use slog::o;
+    ///
+    /// let mut app = tide::App::new();
+    ///
+    /// let root_logger = slog::Logger::root(slog::Discard, o!());
+    /// app.middleware(tide_slog::PerRequestLogger::with_logger(root_logger));
+    /// ```
+    pub fn with_logger(logger: slog::Logger) -> Self {
+        Self {
+            setup: Box::new(move |_cx| logger.clone()),
+        }
+    }
+}
+
+impl<State: Send + Sync + 'static> Middleware<State> for PerRequestLogger<State> {
+    fn handle<'a>(
+        &'a self,
+        mut cx: Context<State>,
+        next: Next<'a, State>,
+    ) -> BoxFuture<'a, Response> {
+        let logger = (self.setup)(&mut cx);
+        cx.extensions_mut().insert(logger);
+        next.run(cx)
+    }
+}
+
+impl<State> std::fmt::Debug for PerRequestLogger<State> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PerRequestLogger")
+            .field("setup", &"[closure]")
+            .finish()
+    }
+}

--- a/tide-slog/src/request_logger.rs
+++ b/tide-slog/src/request_logger.rs
@@ -1,0 +1,74 @@
+use crate::ContextExt;
+use futures::future::BoxFuture;
+use slog::{info, trace};
+use tide_core::{
+    middleware::{Middleware, Next},
+    Context, Response,
+};
+
+/// Middleware that logs minimal request details to the current request's [`slog::Logger`].
+///
+/// Relies on having a [`PerRequestLogger`][crate::PerRequestLogger] middleware instance setup
+/// beforehand to get the logger from.
+///
+/// # Examples
+///
+/// ```
+/// use slog::o;
+///
+/// let mut app = tide::App::new();
+///
+/// let root_logger = slog::Logger::root(slog::Discard, o!());
+/// app.middleware(tide_slog::PerRequestLogger::with_logger(root_logger));
+/// app.middleware(tide_slog::RequestLogger::new());
+/// ```
+#[derive(Debug)]
+pub struct RequestLogger {
+    // In case we want to make this configurable in the future
+    _reserved: (),
+}
+
+impl RequestLogger {
+    /// Create a new [`RequestLogger`] instance.
+    pub fn new() -> Self {
+        Self { _reserved: () }
+    }
+}
+
+impl<State: Send + Sync + 'static> Middleware<State> for RequestLogger {
+    fn handle<'a>(&'a self, cx: Context<State>, next: Next<'a, State>) -> BoxFuture<'a, Response> {
+        Box::pin(async move {
+            let logger = cx.logger().clone();
+            let path = cx.uri().path().to_owned();
+            let method = cx.method().as_str().to_owned();
+
+            trace!(
+                logger,
+                "IN => {method} {path}",
+                method = &method,
+                path = &path
+            );
+
+            let start = std::time::Instant::now();
+            let res = next.run(cx).await;
+            let status = res.status();
+
+            info!(
+                logger,
+                "{method} {path} {status} {elapsed}ms",
+                method = &method,
+                path = &path,
+                status = status.as_str(),
+                elapsed = start.elapsed().as_millis(),
+            );
+
+            res
+        })
+    }
+}
+
+impl Default for RequestLogger {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tide-slog/src/set_slog_scope_logger.rs
+++ b/tide-slog/src/set_slog_scope_logger.rs
@@ -1,0 +1,51 @@
+use crate::ContextExt;
+use futures::future::{BoxFuture, FutureExt as _};
+use slog_scope_futures::FutureExt as _;
+use tide_core::{
+    middleware::{Middleware, Next},
+    Response,
+};
+
+#[cfg_attr(docrs, doc(cfg(feature = "scope")))]
+/// Middleware that ensures the current request's [`slog::Logger`] will be accessible using
+/// [`slog-scope::logger`] during all following processing of the request.
+///
+/// Relies on having a [`PerRequestLogger`][crate::PerRequestLogger] middleware instance setup
+/// beforehand to get the logger from.
+///
+/// This can be used along with [`slog-stdlog`](https://docs.rs/slog-stdlog/) to
+/// integrate per-request logging with middleware that use [`log`](https://docs.rs/log)`.
+///
+/// # Examples
+///
+/// ```
+/// use slog::o;
+///
+/// let root_logger = slog::Logger::root(slog::Discard, o!());
+///
+/// let _guard = slog_scope::set_global_logger(root_logger.clone());
+/// slog_stdlog::init()?;
+///
+/// let mut app = tide::App::new();
+///
+/// app.middleware(tide_slog::PerRequestLogger::with_logger(root_logger));
+/// app.middleware(tide_slog::SetSlogScopeLogger);
+///
+/// // The default tide request logger uses `log`, but since we are using `slog-stdlog` and run
+/// // `SetSlogScopeLogger` first it will be redirected into the per-request logger instance.
+/// app.middleware(tide::middleware::RequestLogger::new());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug)]
+pub struct SetSlogScopeLogger;
+
+impl<State: Send + Sync + 'static> Middleware<State> for SetSlogScopeLogger {
+    fn handle<'a>(
+        &'a self,
+        cx: tide_core::Context<State>,
+        next: Next<'a, State>,
+    ) -> BoxFuture<'a, Response> {
+        let logger = cx.logger().clone();
+        next.run(cx).with_logger(logger).boxed()
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace the existing slog based request logger with more configurable tide-slog integration points.
<!--- Describe your changes in detail -->

## Motivation and Context
Better integration with slog using applications and libraries. Previously there was no way to customise what was logged per-request, and no way to get access to the logger from a request. Now those are both provided via `tide_slog::PerRequestLogger`, which `tide_slog::RequestLogger` will use to log the current request; `tide_slog::SetSlogScopeLogger` can also be used to update the `slog_scope` logger automatically within the context of any request.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Doc tests and usage in my own web app.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
