### PR TITLE
Add async_closure feature gate where needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly-2019-06-02
+rust: nightly-2019-07-08
 cache: cargo
 
 before_script:

--- a/examples/cors.rs
+++ b/examples/cors.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 
 use http::header::HeaderValue;
 use tide::middleware::CorsMiddleware;

--- a/examples/default_headers.rs
+++ b/examples/default_headers.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 
 use tide::middleware::DefaultHeaders;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 fn main() {
     let mut app = tide::App::new();
     app.at("/").get(async move |_| "Hello, world!");

--- a/examples/hello_envlog.rs
+++ b/examples/hello_envlog.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 fn main() {
     env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let mut app = tide::App::new();

--- a/examples/hello_logrs.rs
+++ b/examples/hello_logrs.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 fn main() {
     use log::LevelFilter;
     use log4rs::append::console::ConsoleAppender;

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -51,7 +51,7 @@ async fn set_message(mut cx: Context<Database>) -> EndpointResult<()> {
     if cx.state().set(id, msg) {
         Ok(())
     } else {
-        Err(StatusCode::NOT_FOUND)?
+        Err(StatusCode::NOT_FOUND.into())
     }
 }
 
@@ -60,7 +60,7 @@ async fn get_message(cx: Context<Database>) -> EndpointResult {
     if let Some(msg) = cx.state().get(id) {
         Ok(response::json(msg))
     } else {
-        Err(StatusCode::NOT_FOUND)?
+        Err(StatusCode::NOT_FOUND.into())
     }
 }
 

--- a/examples/runtime.rs
+++ b/examples/runtime.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 
 /// An example of how to run a Tide service on top of `runtime`, this also shows the pieces
 /// necessary if you wish to run a service on some other executor/IO source.

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ use crate::{
 /// on `127.0.0.1:8000` with:
 ///
 /// ```rust, no_run
-/// #![feature(async_await)]
+/// #![feature(async_await, async_closure)]
 ///
 /// let mut app = tide::App::new();
 /// app.at("/hello").get(async move |_| "Hello, world!");
@@ -45,7 +45,7 @@ use crate::{
 /// segments as parameters to endpoints:
 ///
 /// ```rust, no_run
-/// #![feature(async_await)]
+/// #![feature(async_await, async_closure)]
 ///
 /// use tide::error::ResultExt;
 ///
@@ -166,7 +166,7 @@ impl<State: Send + Sync + 'static> App<State> {
     /// respective endpoint of the selected resource. Example:
     ///
     /// ```rust,no_run
-    /// # #![feature(async_await)]
+    /// # #![feature(async_await, async_closure)]
     /// # let mut app = tide::App::new();
     /// app.at("/").get(async move |_| "Hello, world!");
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(any(feature = "nightly", test), feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![feature(async_await, existential_type)]
+#![feature(async_await, async_closure, existential_type)]
 #![warn(
     nonstandard_style,
     rust_2018_idioms,

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 
 use futures::executor::block_on;
 use http_service::Body;

--- a/tide-cors/src/lib.rs
+++ b/tide-cors/src/lib.rs
@@ -3,7 +3,7 @@
 //! ## Examples
 //!
 //! ```rust,no_run
-//! #![feature(async_await)]
+//! #![feature(async_await, async_closure)]
 //!
 //! use http::header::HeaderValue;
 //! use tide_cors::CorsMiddleware;
@@ -30,7 +30,7 @@
 //!
 //! You will probably get a browser alert when running without cors middleware.
 
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 #![warn(
     nonstandard_style,
     rust_2018_idioms,


### PR DESCRIPTION
This PR adds async_closure feature gate to the crates that use the feature, in tests and example to make everything compile and work properly again.

This is related to the recent change done in https://github.com/rust-lang/rust/pull/62292