### PR TITLE
Remove usage of async_closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Ecosystem WG, and **not ready for production use yet**.
 
 fn main() -> Result<(), std::io::Error> {
     let mut app = tide::App::new();
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
     Ok(app.run("127.0.0.1:8000")?)
 }
 ```

--- a/examples/cors.rs
+++ b/examples/cors.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 
 use http::header::HeaderValue;
 use tide::middleware::CorsMiddleware;
@@ -12,7 +12,7 @@ fn main() {
             .allow_methods(HeaderValue::from_static("GET, POST, OPTIONS")),
     );
 
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
 
     app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/default_headers.rs
+++ b/examples/default_headers.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 
 use tide::middleware::DefaultHeaders;
 
@@ -11,7 +11,7 @@ fn main() {
             .header("X-Server", "Tide"),
     );
 
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
 
     app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,6 @@
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 fn main() {
     let mut app = tide::App::new();
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
     app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/hello_envlog.rs
+++ b/examples/hello_envlog.rs
@@ -1,8 +1,8 @@
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 fn main() {
     env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let mut app = tide::App::new();
     app.middleware(tide::middleware::RequestLogger::new());
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
     app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/hello_logrs.rs
+++ b/examples/hello_logrs.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 fn main() {
     use log::LevelFilter;
     use log4rs::append::console::ConsoleAppender;
@@ -13,6 +13,6 @@ fn main() {
 
     let mut app = tide::App::new();
     app.middleware(tide::middleware::RequestLogger::new());
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
     app.run("127.0.0.1:8000").unwrap();
 }

--- a/examples/runtime.rs
+++ b/examples/runtime.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 
 /// An example of how to run a Tide service on top of `runtime`, this also shows the pieces
 /// necessary if you wish to run a service on some other executor/IO source.
@@ -7,7 +7,7 @@
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // First, we create a simple hello world application
     let mut app = tide::App::new();
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
 
     // Instead of using `App::run` to start the application, which implicitly uses a default
     // http-service server, we need to configure a custom server with the executor and IO source we

--- a/rfcs/001-app-new.md
+++ b/rfcs/001-app-new.md
@@ -52,7 +52,7 @@ __no state__
 
 fn main() -> Result<(), failure::Error> {
     let mut app = tide::App::new();
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
     app.serve("127.0.0.1:8000")?;
 }
 ```
@@ -68,7 +68,7 @@ struct State {
 
 fn main() -> Result<(), failure::Error> {
     let mut app = tide::App::with_state(State::default());
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
     app.serve("127.0.0.1:8000")?;
 }
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,10 +30,10 @@ use crate::{
 /// on `127.0.0.1:8000` with:
 ///
 /// ```rust, no_run
-/// #![feature(async_await, async_closure)]
+/// #![feature(async_await)]
 ///
 /// let mut app = tide::App::new();
-/// app.at("/hello").get(async move |_| "Hello, world!");
+/// app.at("/hello").get(|_| async move { "Hello, world!" });
 /// app.run("127.0.0.1:8000");
 /// ```
 ///
@@ -45,7 +45,7 @@ use crate::{
 /// segments as parameters to endpoints:
 ///
 /// ```rust, no_run
-/// #![feature(async_await, async_closure)]
+/// #![feature(async_await)]
 ///
 /// use tide::error::ResultExt;
 ///
@@ -63,7 +63,7 @@ use crate::{
 ///
 /// app.at("/hello/:user").get(hello);
 /// app.at("/goodbye/:user").get(goodbye);
-/// app.at("/").get(async move |_| {
+/// app.at("/").get(|_| async move {
 ///     "Use /hello/{your name} or /goodbye/{your name}"
 /// });
 ///
@@ -166,9 +166,9 @@ impl<State: Send + Sync + 'static> App<State> {
     /// respective endpoint of the selected resource. Example:
     ///
     /// ```rust,no_run
-    /// # #![feature(async_await, async_closure)]
+    /// # #![feature(async_await)]
     /// # let mut app = tide::App::new();
-    /// app.at("/").get(async move |_| "Hello, world!");
+    /// app.at("/").get(|_| async move { "Hello, world!" });
     /// ```
     ///
     /// A path is comprised of zero or many segments, i.e. non-empty strings
@@ -337,9 +337,9 @@ mod tests {
     #[test]
     fn simple_static() {
         let mut router = App::new();
-        router.at("/").get(async move |_| "/");
-        router.at("/foo").get(async move |_| "/foo");
-        router.at("/foo/bar").get(async move |_| "/foo/bar");
+        router.at("/").get(|_| async move { "/" });
+        router.at("/foo").get(|_| async move { "/foo" });
+        router.at("/foo/bar").get(|_| async move { "/foo/bar" });
 
         for path in &["/", "/foo", "/foo/bar"] {
             let res = block_on(simulate_request(&router, path, http::Method::GET));
@@ -351,23 +351,23 @@ mod tests {
     #[test]
     fn nested_static() {
         let mut router = App::new();
-        router.at("/a").get(async move |_| "/a");
+        router.at("/a").get(|_| async move { "/a" });
         router.at("/b").nest(|router| {
-            router.at("/").get(async move |_| "/b");
-            router.at("/a").get(async move |_| "/b/a");
-            router.at("/b").get(async move |_| "/b/b");
+            router.at("/").get(|_| async move { "/b" });
+            router.at("/a").get(|_| async move { "/b/a" });
+            router.at("/b").get(|_| async move { "/b/b" });
             router.at("/c").nest(|router| {
-                router.at("/a").get(async move |_| "/b/c/a");
-                router.at("/b").get(async move |_| "/b/c/b");
+                router.at("/a").get(|_| async move { "/b/c/a" });
+                router.at("/b").get(|_| async move { "/b/c/b" });
             });
-            router.at("/d").get(async move |_| "/b/d");
+            router.at("/d").get(|_| async move { "/b/d" });
         });
         router.at("/a/a").nest(|router| {
-            router.at("/a").get(async move |_| "/a/a/a");
-            router.at("/b").get(async move |_| "/a/a/b");
+            router.at("/a").get(|_| async move { "/a/a/a" });
+            router.at("/b").get(|_| async move { "/a/a/b" });
         });
         router.at("/a/b").nest(|router| {
-            router.at("/").get(async move |_| "/a/b");
+            router.at("/").get(|_| async move { "/a/b" });
         });
 
         for failing_path in &["/", "/a/a", "/a/b/a"] {
@@ -393,9 +393,9 @@ mod tests {
     fn multiple_methods() {
         let mut router = App::new();
         router.at("/a").nest(|router| {
-            router.at("/b").get(async move |_| "/a/b GET");
+            router.at("/b").get(|_| async move { "/a/b GET" });
         });
-        router.at("/a/b").post(async move |_| "/a/b POST");
+        router.at("/a/b").post(|_| async move { "/a/b POST" });
 
         for (path, method) in &[("/a/b", http::Method::GET), ("/a/b", http::Method::POST)] {
             let res = block_on(simulate_request(&router, path, method.clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(any(feature = "nightly", test), feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![feature(async_await, async_closure, existential_type)]
+#![feature(async_await, existential_type)]
 #![warn(
     nonstandard_style,
     rust_2018_idioms,

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 
 use futures::executor::block_on;
 use http_service::Body;
@@ -169,7 +169,7 @@ fn invalid_wildcard() {
 #[test]
 fn nameless_wildcard() {
     let mut app = tide::App::new();
-    app.at("/echo/:").get(async move |_| "");
+    app.at("/echo/:").get(|_| async move { "" });
 
     let mut server = make_server(app.into_http_service()).unwrap();
 

--- a/tide-cors/README.md
+++ b/tide-cors/README.md
@@ -21,7 +21,7 @@ fn main() {
             .allow_methods(HeaderValue::from_static("GET, POST, OPTIONS")),
     );
 
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
 
     app.run("127.0.0.1:8000").unwrap();
 }

--- a/tide-cors/src/lib.rs
+++ b/tide-cors/src/lib.rs
@@ -3,7 +3,7 @@
 //! ## Examples
 //!
 //! ```rust,no_run
-//! #![feature(async_await, async_closure)]
+//! #![feature(async_await)]
 //!
 //! use http::header::HeaderValue;
 //! use tide_cors::CorsMiddleware;
@@ -17,7 +17,7 @@
 //!             .allow_methods(HeaderValue::from_static("GET, POST, OPTIONS")),
 //!     );
 //!
-//!     app.at("/").get(async move |_| "Hello, world!");
+//!     app.at("/").get(|_| async move { "Hello, world!" });
 //!
 //!     app.run("127.0.0.1:8000").unwrap();
 //! }
@@ -30,7 +30,7 @@
 //!
 //! You will probably get a browser alert when running without cors middleware.
 
-#![feature(async_await, async_closure)]
+#![feature(async_await)]
 #![warn(
     nonstandard_style,
     rust_2018_idioms,

--- a/tide-cors/src/middleware.rs
+++ b/tide-cors/src/middleware.rs
@@ -169,7 +169,7 @@ mod test {
 
     fn app() -> tide::App<()> {
         let mut app = tide::App::new();
-        app.at(ENDPOINT).get(async move |_| "Hello World");
+        app.at(ENDPOINT).get(|_| async move { "Hello World" });
 
         app
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`async_closure` won't be stable any time soon and are equivalent to closures which return async blocks. 

Related: https://github.com/rust-lang-nursery/futures-rs/pull/1716#issuecomment-508964777

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
