### PR TITLE
Upgrade mime_guess to version 2.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ juniper = "0.13.0"
 log = "0.4.6"
 log4rs = "0.8.3"
 mime = "0.3.13"
-mime_guess = "2.0.0-alpha.6"
+mime_guess = "2.0.1"
 percent-encoding = "2.0.0"
 serde = { version = "1.0.91", features = ["derive"] }
 tera = "0.11"


### PR DESCRIPTION
Upgrade `mime_guess` to version `2.0.1`.

## Description

My hunch is that Dependabot may have ignored this since we explicitly set an `alpha` version of the dependency.  Since `2.0` has now been released, I suggest we update to it.

## Motivation and Context

I'm seeing issues with the `from_path` function used in [`examples/staticfile.rs`](https://github.com/rustasync/tide/blob/master/examples/staticfile.rs#L71) when running tests locally.

## How Has This Been Tested?

All existing tests passed. Examples compiled successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
