### PR TITLE
Update http-service in tide-panic to match rest of crate

### DIFF
--- a/tide-panic/Cargo.toml
+++ b/tide-panic/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/rustasync/tide"
 [dependencies]
 futures-preview = "0.3.0-alpha.17"
 http = "0.1"
-http-service = "0.2.0"
+http-service = "0.3.0"
 tide-core = { path = "../tide-core" }

--- a/tide-panic/src/lib.rs
+++ b/tide-panic/src/lib.rs
@@ -4,7 +4,7 @@
 //! Tide's default panic handling is not usable by your application. Before using these you should
 //! have a good understanding of how the different components involved in [`std::panic`] works.
 
-#![feature(async_await, doc_cfg)]
+#![feature(doc_cfg)]
 #![warn(
     nonstandard_style,
     rust_2018_idioms,


### PR DESCRIPTION
## Description
At the moment the tide example does not compile on nightly. Updating the version corrects this.

## Motivation and Context
Closes #311 

## How Has This Been Tested?
Unit tests pass.
Example code is now compiling.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
