### PR TITLE
cookies: is &mut self required?

### DIFF
--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -2,7 +2,7 @@ use cookie::Cookie;
 use tide::{cookies::ContextExt, middleware::CookiesMiddleware, Context};
 
 /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
-async fn retrieve_cookie(mut cx: Context<()>) -> String {
+async fn retrieve_cookie(cx: Context<()>) -> String {
     format!("hello cookies: {:?}", cx.get_cookie("hello").unwrap())
 }
 

--- a/tide-cookies/src/data.rs
+++ b/tide-cookies/src/data.rs
@@ -29,7 +29,7 @@ impl CookieData {
 /// An extension to `Context` that provides cached access to cookies
 pub trait ContextExt {
     /// returns a `Cookie` by name of the cookie
-    fn get_cookie(&mut self, name: &str) -> Result<Option<Cookie<'static>>, StringError>;
+    fn get_cookie(&self, name: &str) -> Result<Option<Cookie<'static>>, StringError>;
 
     /// Add cookie to the cookie jar
     fn set_cookie(&mut self, cookie: Cookie<'static>) -> Result<(), StringError>;
@@ -40,7 +40,7 @@ pub trait ContextExt {
 }
 
 impl<State> ContextExt for Context<State> {
-    fn get_cookie(&mut self, name: &str) -> Result<Option<Cookie<'static>>, StringError> {
+    fn get_cookie(&self, name: &str) -> Result<Option<Cookie<'static>>, StringError> {
         let cookie_data = self
             .extensions()
             .get::<CookieData>()

--- a/tide-cookies/src/middleware.rs
+++ b/tide-cookies/src/middleware.rs
@@ -78,8 +78,8 @@ mod tests {
 
     static COOKIE_NAME: &str = "testCookie";
 
-    /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
-    async fn retrieve_cookie(mut cx: Context<()>) -> String {
+    /// Tide will use the the  `Cookies`'s `Extract` implementation to build this parameter.
+    async fn retrieve_cookie(cx: Context<()>) -> String {
         cx.get_cookie(COOKIE_NAME)
             .unwrap()
             .unwrap()


### PR DESCRIPTION
`&mut self` doesn't seem to be required, as mentioned in #316.

## Description

Change cookie trait function signature on `get_cookie` from `&mut self` to `&self`.

## Motivation and Context

Tide seems to compile fine without requiring a mutable reference. Unsure why the previous behavior may have been required, but I believe there's little need to require mutability when reading cookie values.

## How Has This Been Tested?

Existing tests passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
