### PR TITLE
CORS middleware: better handling of Origin

### DIFF
--- a/tide-cors/src/middleware.rs
+++ b/tide-cors/src/middleware.rs
@@ -193,14 +193,12 @@ impl CorsMiddleware {
 impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
     fn handle<'a>(&'a self, cx: Context<State>, next: Next<'a, State>) -> BoxFuture<'a, Response> {
         Box::pin(async move {
-            let origin = if let Some(origin) = cx.request().headers().get(header::ORIGIN) {
-                origin.clone()
-            } else {
-                return http::Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Body::empty())
-                    .unwrap();
-            };
+            let origin = cx
+                .request()
+                .headers()
+                .get(header::ORIGIN)
+                .cloned()
+                .unwrap_or(HeaderValue::from_static(""));
 
             if !self.is_valid_origin(&origin) {
                 return http::Response::builder()

--- a/tide-cors/src/middleware.rs
+++ b/tide-cors/src/middleware.rs
@@ -399,7 +399,7 @@ mod test {
         let mut server = make_server(app.into_http_service()).unwrap();
         let res = server.simulate(request).unwrap();
 
-        assert_eq!(res.status(), 400);
+        assert_eq!(res.status(), 200);
     }
 
     #[test]

--- a/tide-cors/src/middleware.rs
+++ b/tide-cors/src/middleware.rs
@@ -198,7 +198,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
                 .headers()
                 .get(header::ORIGIN)
                 .cloned()
-                .unwrap_or(HeaderValue::from_static(""));
+                .unwrap_or_else(|| HeaderValue::from_static(""));
 
             if !self.is_valid_origin(&origin) {
                 return http::Response::builder()


### PR DESCRIPTION
no origin header should be treated as an empty origin header

otherwise, simple HTTP requests like ones made with `curl` will fail with 400 bad request

Pretty much any other framework/server treats the absence of an `origin` header the same as empty `origin` header

## Description

Passing no `origin` header should be treated as an empty origin header

otherwise, simple HTTP requests like ones made with `curl` will fail with 400 bad request

Pretty much any other framework/server treats the absence of an `origin` header the same as empty `origin` header

## Motivation and Context

Fixes simple HTTP requests, such as ones made with `curl`

## How Has This Been Tested?

`curl localhost:8000`

`curl -H 'Origin: something.com' localhost:8000`

And to test the cases where it should be rejected, just set the origin to something and then see if any other origin will be rejected



## Types of changes

- [ ] changed `src/middleware.rs` to apply the change

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
