### PR TITLE
Nested router example

### DIFF
--- a/examples/nested_router.rs
+++ b/examples/nested_router.rs
@@ -1,0 +1,15 @@
+use tide::App;
+
+fn main() {
+    let mut app = App::new();
+    app.at("/gates").nest(|router| {
+        router
+            .at("/")
+            .get(|_| async move { "This is an area in front of the gates" });
+        router.at("/open").get(|_| async move { "Open the gates!" });
+        router
+            .at("/close")
+            .get(|_| async move { "Close the gates!" });
+    });
+    app.run("127.0.0.1:8000").unwrap();
+}


### PR DESCRIPTION
Added nested router example. Similar example was here before: https://github.com/rustasync/tide/commit/4bb3d3f19861d567ad319372d4ce93a7c04a7970, but disappeared during refactoring.